### PR TITLE
Allow using actual js functions in Rivescript.setSubroutine

### DIFF
--- a/eg/web-client/chat.html
+++ b/eg/web-client/chat.html
@@ -74,6 +74,12 @@ rs.loadFile([
 	"brain/javascript.rive"
 	], on_load_success, on_load_error);
 
+// You can register objects that can then be called 
+// using <call></call> syntax
+rs.setSubroutine('fancyJSObject', function(rs, args){
+	// doing complex stuff here
+});
+
 function on_load_success () {
 	$("#message").removeAttr("disabled");
 	$("#message").attr("placeholder", "Send message");

--- a/src/lang/javascript.coffee
+++ b/src/lang/javascript.coffee
@@ -23,20 +23,24 @@ class JSObjectHandler
     @_objects = {}
 
   ##
-  # void load (string name, string[] code)
+  # void load (string name, string[]|Function code)
   #
   # Called by the RiveScript object to load JavaScript code.
   ##
   load: (name, code) ->
-    # We need to make a dynamic JavaScript function.
-    source = "this._objects[\"" + name + "\"] = function(rs, args) {\n" \
-      + code.join("\n") \
-      + "}\n"
+    if typeof code is "function"
+      # If code is just a js function, store the reference as is
+      @_objects[name] = code
+    else
+      # We need to make a dynamic JavaScript function.
+      source = "this._objects[\"" + name + "\"] = function(rs, args) {\n" \
+        + code.join("\n") \
+        + "}\n"
 
-    try
-      eval source
-    catch e
-      @_master.warn "Error evaluating JavaScript object: " + e.message
+      try
+        eval source
+      catch e
+        @_master.warn "Error evaluating JavaScript object: " + e.message
 
   ##
   # string call (RiveScript rs, string name, string[] fields)

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -790,3 +790,46 @@ exports.test_punctuation = (test) ->
   bot.reply("Hello bot", "Hello human!")
   bot.reply("Hello, bot!", "ERR: No Reply Matched")
   test.done()
+
+exports.test_js_string_in_setSubroutine = (test) ->
+  bot = new TestCase(test, """
+    + hello
+    - hello <call>helper <star></call>
+  """)
+
+  input = "hello there"
+
+  bot.rs.setSubroutine("helper", ["return 'person';"])
+  bot.reply("hello", "hello person")
+  test.done()
+
+exports.test_function_in_setSubroutine = (test) ->
+  bot = new TestCase(test, """
+    + *
+    - hello person<call>helper <star></call>
+  """)
+
+  input = "hello there"
+
+  bot.rs.setSubroutine("helper", (rs, args) ->
+    test.ok(args.length is 2)
+    test.equal(rs, bot.rs)
+    test.equal(args[0], "hello")
+    test.equal(args[1], "there")
+    test.done()
+  )
+
+  bot.reply(input, "hello person")
+
+exports.test_function_in_setSubroutine_return_value = (test) ->
+  bot = new TestCase(test, """
+    + hello
+    - hello <call>helper <star></call>
+  """)
+
+  bot.rs.setSubroutine("helper", (rs, args) ->
+    "person"
+  )
+
+  bot.reply("hello", "hello person")
+  test.done()


### PR DESCRIPTION
Hello Noah,

This adds support for passing actual js functions to **setSubroutine** (as opposed to just strings). We are building a set of extensions for rivescript to leverage certain components in our system and I found this feature useful for several reasons:
- taking advantage of closures to reference our components
- better tooling support (write js with syntax coloring and all that jazz)
- support for transpilers (we run on babel so it's nice to be able to write the same flavor of js in subroutines as well) 