### PR TITLE
Include objects macros in output of deparse and stringify.

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -503,6 +503,21 @@ class Parser
             source.push "! #{begin} #{key} = " + value.join(pipes)
         source.push ""
 
+    # Do objects. Requires stripping out the actual function wrapper
+    if deparsed.objects
+      for lang of deparsed.objects
+        if deparsed.objects[lang] and deparsed.objects[lang]._objects
+          for func of deparsed.objects[lang]._objects
+            source.push "> object " + func + " " + lang
+            source.push( deparsed.objects[lang]._objects[func].toString()
+              .match(/function[^{]+\{\n*([\s\S]*)\}\;?\s*$/m)[1]
+              .trim()
+              .split("\n")
+              .map (ln)-> "\t" + ln
+              .join("\n")
+            )
+            source.push "< object\n"
+
     # Begin block triggers.
     if deparsed.begin.triggers?.length
       source.push "> begin\n"

--- a/src/rivescript.coffee
+++ b/src/rivescript.coffee
@@ -456,6 +456,11 @@ class RiveScript
       topics: utils.clone(@_topics)
       inherits: utils.clone(@_inherits)
       includes: utils.clone(@_includes)
+      objects: {}
+
+    for key of this._handlers
+      result.objects[key] =
+        _objects: utils.clone(this._handlers[key]._objects)
 
     # Begin topic.
     if result.topics.__begin__?

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -1018,3 +1018,22 @@ exports.test_async_and_sync_subroutines_together = (test) ->
   bot.rs.replyAsync(bot.username, "my name is Rive").then (reply) ->
     test.equal(reply, "hello there stranger!")
     test.done()
+
+
+exports.test_stringify_with_objects = (test) ->
+  bot = new TestCase(test, """
+    > object hello javascript
+      return \"Hello\";
+    < object
+    + my name is *
+    - hello there<call>exclaim</call>
+  """)
+
+  bot.rs.setSubroutine("exclaim", (rs, args) ->
+    return "!"
+  )
+
+  src = bot.rs.stringify()
+  expect = '! version = 2.0\n! local concat = none\n\n> object hello javascript\n\treturn "Hello";\n< object\n\n> object exclaim javascript\n\treturn "!";\n< object\n\n+ my name is *\n- hello there<call>exclaim</call>\n'
+  test.equal(src, expect)
+  test.done()


### PR DESCRIPTION
This add ability to output object macros in `stringify()`. Pull request includes test to validate output matches expected string.

Hoping this passes muster and is merged in quickly. This is necessary for a project that requires validating and syncing compiled Rive files for access and reading by multiple Rive workers.

(Loving Rivescript btw!)