### PR TITLE
Allow loadDirectory() to recursively load files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "fs-readdir-recursive": "^1.0.0",
     "rsvp": "^3.1.0"
   }
 }

--- a/test/fixtures/recursive/test.rive
+++ b/test/fixtures/recursive/test.rive
@@ -1,0 +1,2 @@
++ did the recursive directory rivescript load
+- Yes, the recursive directory rivescript loaded.

--- a/test/fixtures/test.rive
+++ b/test/fixtures/test.rive
@@ -1,0 +1,2 @@
++ did the root directory rivescript load
+- Yes, the root directory rivescript loaded.

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -1037,3 +1037,20 @@ exports.test_stringify_with_objects = (test) ->
   expect = '! version = 2.0\n! local concat = none\n\n> object hello javascript\n\treturn "Hello";\n< object\n\n> object exclaim javascript\n\treturn "!";\n< object\n\n+ my name is *\n- hello there<call>exclaim</call>\n'
   test.equal(src, expect)
   test.done()
+
+
+exports.load_directory_recursively = (test) ->
+  bot = new TestCase(test, """
+    + *
+    - No, this failed.
+  """)
+
+  bot.rs.loadDirectory('./test/fixtures', ->
+    bot.rs.sortReplies()
+    bot.reply("Did the root directory rivescript load?", "Yes, the root directory rivescript loaded.")
+    bot.reply("Did the recursive directory rivescript load?", "Yes, the recursive directory rivescript loaded.")
+    test.done()
+  , ->
+    test.equal(true, false) # Throw error
+  )
+


### PR DESCRIPTION
`loadDirectory()` should allow for recursive lookup of Rivescript files inside a directory with child directories. 

Pull request includes update to loadDirectory() and a test case ensuring that Rivescript files in child directories are also located and parsed.

For our large project, it is easier for our editors to manage smaller files organized in subdirectories inside our main language directory. NodeJS's standard readdir is a bit lacking in ability to dive into child directories.

It does use the `fs-readdir-recursive` module, which while I would have preferred to not require an additional module, it does make the overall functionality of `loadDirectory()` better.