### PR TITLE
allow * condition to respect ^ continue concat format

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -438,7 +438,7 @@ class Brain
               left = utils.strip(condition[1])
               eq   = condition[2]
               right = utils.strip(condition[3])
-              potreply = utils.strip(halves[1])
+              potreply = halves[1].trim()
 
               # Process tags all around
               left  = @processTags(user, msg, left, stars, thatstars, step, scope)

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -1102,3 +1102,69 @@ exports.load_directory_recursively = (test) ->
     test.equal(true, false) # Throw error
   )
 
+exports.test_concat_with_conditionals = (test) ->
+  # Newline
+  bot = new TestCase(test, """
+    ! local concat = newline
+
+    + test *
+    * <star1> == a => First A line
+    ^ Second A line
+    ^ Third A line
+    - First B line
+    ^ Second B line
+    ^ Third B line
+  """)
+
+  bot.reply("test a", "First A line\nSecond A line\nThird A line")
+  bot.reply("test b", "First B line\nSecond B line\nThird B line")
+
+  # Space
+  bot = new TestCase(test, """
+    ! local concat = space
+
+    + test *
+    * <star1> == a => First A line
+    ^ Second A line
+    ^ Third A line
+    - First B line
+    ^ Second B line
+    ^ Third B line
+  """)
+
+  bot.reply("test a", "First A line Second A line Third A line")
+  bot.reply("test b", "First B line Second B line Third B line")
+
+  # No concat
+  bot = new TestCase(test, """
+    + test *
+    * <star1> == a => First A line
+    ^ Second A line
+    ^ Third A line
+    - First B line
+    ^ Second B line
+    ^ Third B line
+  """)
+
+  bot.reply("test a", "First A lineSecond A lineThird A line")
+  bot.reply("test b", "First B lineSecond B lineThird B line")
+
+  test.done()
+
+
+exports.test_concat_space_with_conditionals = (test) ->
+  bot = new TestCase(test, """
+    ! local concat = newline
+
+    + test *
+    * <star1> == a => First A line
+    ^ Second A line
+    ^ Third A line
+    - First B line
+    ^ Second B line
+    ^ Third B line
+  """)
+
+  bot.reply("test a", "First A line\nSecond A line\nThird A line")
+  bot.reply("test b", "First B line\nSecond B line\nThird B line")
+  test.done()


### PR DESCRIPTION
this is a fix for #88. includes tests across all three available concat methods (none, space, newline)