### PR TITLE
<@> redirect does not work if <star> is undefined

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -789,9 +789,6 @@ class Brain
     reply = reply.replace(/\\n/ig, "\n")
     reply = reply.replace(/\\#/ig, "#")
 
-    # Prevent empty redirects
-    reply = reply.replace(/\{@\}/ig, "{@*}")
-
     # {random}
     match = reply.match(/\{random\}(.+?)\{\/random\}/i)
     giveup = 0
@@ -933,7 +930,7 @@ class Brain
       match = reply.match(/\{topic=(.+?)\}/i) # Look for more
 
     # Inline redirector
-    match = reply.match(/\{@(.+?)\}/)
+    match = reply.match(/\{@([^\}]*?)\}/)
     giveup = 0
     while match
       giveup++
@@ -945,7 +942,7 @@ class Brain
       @say "Inline redirection to: #{target}"
       subreply = @_getReply(user, target, "normal", step+1, scope)
       reply = reply.replace(new RegExp("\\{@" + utils.quotemeta(target) + "\\}", "i"), subreply)
-      match = reply.match(/\{@(.+?)\}/)
+      match = reply.match(/\{@([^\}]*?)\}/)
 
     return reply
 

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -789,6 +789,9 @@ class Brain
     reply = reply.replace(/\\n/ig, "\n")
     reply = reply.replace(/\\#/ig, "#")
 
+    # Prevent empty redirects
+    reply = reply.replace(/\{@\}/ig, "{@*}")
+
     # {random}
     match = reply.match(/\{random\}(.+?)\{\/random\}/i)
     giveup = 0

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -1168,3 +1168,75 @@ exports.test_concat_space_with_conditionals = (test) ->
   bot.reply("test a", "First A line\nSecond A line\nThird A line")
   bot.reply("test b", "First B line\nSecond B line\nThird B line")
   test.done()
+
+
+exports.test_redirect_with_undefined_input = (test) ->
+  # <@> test
+  bot = new TestCase(test, """
+    + test
+    - {topic=test}{@hi}
+
+    > topic test
+      + hi
+      - hello
+
+      + *
+      - {topic=random}<@>
+    < topic
+
+    + *
+    - Wildcard!
+  """)
+
+  bot.reply("test", "hello")
+  bot.reply("?", "Wildcard!")
+
+
+  # empty variable test
+  bot = new TestCase(test, """
+    ! var globaltest = set test name test
+
+    + test
+    - {topic=test}{@<get test_name>}
+
+    + test without redirect
+    - {topic=test}<get test_name>
+
+    + set test name *
+    - <set test_name=<star>>{@test}
+
+    + get global test
+    @ <bot globaltest>
+
+    + get bad global test
+    @ <bot badglobaltest>
+
+    > topic test
+      + test
+      - hello <get test_name>!{topic=random}
+
+      + *
+      - {topic=random}<@>
+    < topic
+
+    + *
+    - Wildcard!
+  """)
+
+  # No variable set, should go through wildcard
+  bot.reply("test", "Wildcard!")
+  bot.reply("test without redirect", "undefined")
+
+  # Variable set, should respond with text
+  bot.reply("set test name test", "hello test!")
+
+  # Different variable set, should get wildcard
+  bot.reply("set test name newtest", "Wildcard!")
+
+  # Test redirects using bot variable.
+  bot.reply("get global test", "hello test!")
+  bot.reply("get bad global test", "Wildcard!")
+
+
+
+  test.done()

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -1185,11 +1185,11 @@ exports.test_redirect_with_undefined_input = (test) ->
     < topic
 
     + *
-    - Wildcard!
+    - Wildcard "<star>"!
   """)
 
   bot.reply("test", "hello")
-  bot.reply("?", "Wildcard!")
+  bot.reply("?", "Wildcard \"\"!")
 
 
   # empty variable test
@@ -1220,22 +1220,22 @@ exports.test_redirect_with_undefined_input = (test) ->
     < topic
 
     + *
-    - Wildcard!
+    - Wildcard "<star>"!
   """)
 
   # No variable set, should go through wildcard
-  bot.reply("test", "Wildcard!")
+  bot.reply("test", "Wildcard \"undefined\"!")
   bot.reply("test without redirect", "undefined")
 
   # Variable set, should respond with text
   bot.reply("set test name test", "hello test!")
 
   # Different variable set, should get wildcard
-  bot.reply("set test name newtest", "Wildcard!")
+  bot.reply("set test name newtest", "Wildcard \"newtest\"!")
 
   # Test redirects using bot variable.
   bot.reply("get global test", "hello test!")
-  bot.reply("get bad global test", "Wildcard!")
+  bot.reply("get bad global test", "Wildcard \"undefined\"!")
 
 
 


### PR DESCRIPTION
Do not allow redirects to be blank if `<star>`, `<bot>`, `<get>` returns an undefined string.

See issue #92 for further details.