### PR TITLE
Escape newlines in stringify()

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -470,7 +470,7 @@ class Parser
 
         if t.reply
           for r in t.reply
-            output.push "#{id}- #{r.replace(/\n/mg, "\n" + id + "^ ")}"
+            output.push "#{id}- #{r.replace(/\n/mg, "\\n")}"
 
         output.push ""
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -470,7 +470,7 @@ class Parser
 
         if t.reply
           for r in t.reply
-            output.push "#{id}- #{r}"
+            output.push "#{id}- #{r.replace(/\n/mg, "\n" + id + "^ ")}"
 
         output.push ""
 
@@ -571,7 +571,7 @@ class Parser
           tagged = true
 
       if tagged
-        source.push "> topic #{topic} " + tagline.join(" ") + "\n"
+        source.push ("> topic #{topic} " + tagline.join(" ")).trim() + "\n"
 
       source.push.apply source, _writeTriggers(deparsed.topics[topic], tagged)
 

--- a/test/test-objects.coffee
+++ b/test/test-objects.coffee
@@ -305,6 +305,7 @@ exports.test_stringify_with_objects = (test) ->
     < object
     + my name is *
     - hello there<call>exclaim</call>
+    ^ and i like continues
   """)
 
   bot.rs.setSubroutine("exclaim", (rs) ->
@@ -312,6 +313,6 @@ exports.test_stringify_with_objects = (test) ->
   )
 
   src = bot.rs.stringify()
-  expect = '! version = 2.0\n! local concat = none\n\n> object hello javascript\n\treturn "Hello";\n< object\n\n> object exclaim javascript\n\treturn "!";\n< object\n\n+ my name is *\n- hello there<call>exclaim</call>\n'
+  expect = '! version = 2.0\n! local concat = none\n\n> object hello javascript\n\treturn "Hello";\n< object\n\n> object exclaim javascript\n\treturn "!";\n< object\n\n+ my name is *\n- hello there<call>exclaim</call>and i like continues\n'
   test.equal(src, expect)
   test.done()

--- a/test/test-options.coffee
+++ b/test/test-options.coffee
@@ -137,6 +137,6 @@ exports.test_concat_newline_stringify = (test) ->
   """)
 
   src = bot.rs.stringify()
-  expect = '! version = 2.0\n! local concat = none\n\n+ test *\n- First B line\n^ Second B line\n^ Third B line\n\n> topic a_cool_topic\n\n\t+ hello\n\t- Oh hi there.\n\t^ Do you liek turtles?\n\n< topic\n'
+  expect = '! version = 2.0\n! local concat = none\n\n+ test *\n- First B line\\nSecond B line\\nThird B line\n\n> topic a_cool_topic\n\n\t+ hello\n\t- Oh hi there.\\nDo you liek turtles?\n\n< topic\n'
   test.equal(src, expect)
   test.done()

--- a/test/test-options.coffee
+++ b/test/test-options.coffee
@@ -118,3 +118,25 @@ exports.test_concat_space_with_conditionals = (test) ->
   bot.reply("test a", "First A line\nSecond A line\nThird A line")
   bot.reply("test b", "First B line\nSecond B line\nThird B line")
   test.done()
+
+exports.test_concat_newline_stringify = (test) ->
+  bot = new TestCase(test, """
+    ! local concat = newline
+
+    + test *
+    - First B line
+    ^ Second B line
+    ^ Third B line
+
+    > topic a_cool_topic
+      + hello
+      - Oh hi there.
+      ^ Do you liek turtles?
+    < topic
+
+  """)
+
+  src = bot.rs.stringify()
+  expect = '! version = 2.0\n! local concat = none\n\n+ test *\n- First B line\n^ Second B line\n^ Third B line\n\n> topic a_cool_topic\n\n\t+ hello\n\t- Oh hi there.\n\t^ Do you liek turtles?\n\n< topic\n'
+  test.equal(src, expect)
+  test.done()


### PR DESCRIPTION
Newlines in replies need to be escaped so that they do not render as actual newlines in stringify() output.

Without it, newlines will cause output to be invalid, for example:

```
! version = 2.0
! local concat = none

+ hello
- Hi!
Nice to meet you.
```

when it should correctly output:

```
! version = 2.0
! local concat = none

+ hello
- Hi!\nNice to meet you.
```

Includes tests. Also trims extra whitespace outputted after `> topic name `.