### PR TITLE
Piped array with a blank ending causes matching errors

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -807,9 +807,6 @@ class Brain
       else
         random = text.split(" ")
 
-      # Delete any empty randoms.
-      # random = random.filter (val)-> val != ''
-
       output = random[ parseInt(Math.random() * random.length) ]
 
       reply = reply.replace(new RegExp("\\{random\\}" + utils.quotemeta(text) + "\\{\\/random\\}", "ig")

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -596,6 +596,9 @@ class Brain
     regexp = regexp.replace(/_/g,  "(\\w+?)") # Convert _ into (\w+?)
     regexp = regexp.replace(/\{weight=\d+\}/g, "") # Remove {weight} tags
     regexp = regexp.replace(/<zerowidthstar>/g, "(.*?)")
+    regexp = regexp.replace(/\|{2,}/, '|') # Remove empty entities
+    regexp = regexp.replace(/(\(|\[)\|/g, '$1') # Remove empty entities from start of alt/opts
+    regexp = regexp.replace(/\|(\)|\])/g, '$1') # Remove empty entities from end of alt/opts
 
     # UTF-8 mode special characters.
     if @utf8
@@ -803,6 +806,9 @@ class Brain
         random = text.split("|")
       else
         random = text.split(" ")
+
+      # Delete any empty randoms.
+      # random = random.filter (val)-> val != ''
 
       output = random[ parseInt(Math.random() * random.length) ]
 

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -602,6 +602,12 @@ class Parser
       if not line.match(/^.+(?:\s+.+|)\s*=\s*.+?$/)
         return "Invalid format for !Definition line: must be
                 '! type name = value' OR '! type = value'"
+      else if line.match(/^array/)
+        if line.match(/\=\s?\||\|\s?$/)
+          return "Piped arrays can't begin or end with a |"
+        else if line.match(/\|\|/)
+          return "Piped arrays can't include blank entries"
+
     else if cmd is ">"
       # > Label
       # - The "begin" label must have only one argument ("begin")
@@ -636,6 +642,14 @@ class Parser
       else if line.match(/[^a-z0-9(|)\[\]*_#@{}<>=\s]/)
         return "Triggers may only contain lowercase letters, numbers, and
                 these symbols: ( | ) [ ] * _ # { } < > ="
+      else if line.match(/\(\||\|\)/)
+        return "Piped alternations can't begin or end with a |"
+      else if line.match(/\([^\)].+\|\|.+\)/)
+        return "Piped alternations can't include blank entries"
+      else if line.match(/\[\||\|\]/)
+        return "Piped optionals can't begin or end with a |"
+      else if line.match(/\[[^\]].+\|\|.+\]/)
+        return "Piped optionals can't include blank entries"
 
       # Count the brackets.
       chars = line.split ""

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -306,6 +306,9 @@ class Parser
               for field, i in fields
                 fields[i] = fields[i].replace(/\\s/ig, " ")
 
+              # Delete any empty fields.
+              fields = fields.filter (val)-> val != ''
+
               ast.begin.array[name] = fields
 
             when "sub"

--- a/test/test-triggers.coffee
+++ b/test/test-triggers.coffee
@@ -123,3 +123,20 @@ exports.test_weighted_triggers = (test) ->
   bot.reply("Can you run a Google search for Node", "Sure!")
   bot.reply("Can you run a Google search for Node or something", "Or something. Sure!")
   test.done()
+
+
+exports.test_empty_piped_arrays = (test) ->
+  bot = new TestCase(test, """
+    ! array hello = hi|hey|sup|yo|
+
+    + [*] @hello [*]
+    - Oh hello there.
+
+    + *
+    - Anything else?
+  """)
+  bot.reply("Hey!", "Oh hello there.")
+  bot.reply("sup", "Oh hello there.")
+  bot.reply("Bye!", "Anything else?")
+  bot.reply("Love you", "Anything else?")
+  test.done()

--- a/test/test-triggers.coffee
+++ b/test/test-triggers.coffee
@@ -124,10 +124,21 @@ exports.test_weighted_triggers = (test) ->
   bot.reply("Can you run a Google search for Node or something", "Or something. Sure!")
   test.done()
 
-
 exports.test_empty_piped_arrays = (test) ->
+  errors = []
+  expected_errors = [
+    'Syntax error: Piped arrays can\'t begin or end with a | at stream() line 1 near ! array hello = hi|hey|sup|yo|'
+    'Syntax error: Piped arrays can\'t begin or end with a | at stream() line 2 near ! array something = |something|some thing'
+    'Syntax error: Piped arrays can\'t include blank entries at stream() line 3 near ! array nothing = nothing||not a thing'
+  ]
+
+  console.error = (text)->
+    errors.push(text)
+
   bot = new TestCase(test, """
     ! array hello = hi|hey|sup|yo|
+    ! array something = |something|some thing
+    ! array nothing = nothing||not a thing
 
     + [*] @hello [*]
     - Oh hello there.
@@ -135,8 +146,90 @@ exports.test_empty_piped_arrays = (test) ->
     + *
     - Anything else?
   """)
+
+  # Check that errors were thrown
+  test.deepEqual(errors, expected_errors)
+
+  # We also fix these, so these should also work
   bot.reply("Hey!", "Oh hello there.")
   bot.reply("sup", "Oh hello there.")
+  bot.reply("Bye!", "Anything else?")
+  bot.reply("Love you", "Anything else?")
+  test.done()
+
+exports.test_empty_piped_alternations = (test) ->
+  errors = []
+  expected_errors = [
+    'Syntax error: Piped alternations can\'t begin or end with a | at stream() line 1 near + [*] (hi|hey|sup|yo|) [*]'
+    'Syntax error: Piped alternations can\'t begin or end with a | at stream() line 4 near + [*] (|good|great|nice) [*]'
+    'Syntax error: Piped alternations can\'t include blank entries at stream() line 7 near + [*] (mild|warm||hot) [*]'
+  ]
+
+  console.error = (text)->
+    errors.push(text)
+
+  bot = new TestCase(test, """
+    + [*] (hi|hey|sup|yo|) [*]
+    - Oh hello there.
+
+    + [*] (|good|great|nice) [*]
+    - Oh nice!
+
+    + [*] (mild|warm||hot) [*]
+    - Purrfect.
+
+    + *
+    - Anything else?
+  """)
+
+  # Check that errors were thrown
+  test.deepEqual(errors, expected_errors)
+
+  # We also fix these, so these should also work
+  bot.reply("Hey!", "Oh hello there.")
+  bot.reply("sup", "Oh hello there.")
+  bot.reply("that's nice to hear", "Oh nice!")
+  bot.reply("so good", "Oh nice!")
+  bot.reply("You're hot!", "Purrfect.")
+  bot.reply("Bye!", "Anything else?")
+  bot.reply("Love you", "Anything else?")
+  test.done()
+
+
+exports.test_empty_piped_optionals = (test) ->
+  errors = []
+  expected_errors = [
+    'Syntax error: Piped optionals can\'t begin or end with a | at stream() line 1 near + bot [*] [hi|hey|sup|yo|] [*] to me'
+    'Syntax error: Piped optionals can\'t begin or end with a | at stream() line 4 near + dog [*] [|good|great|nice] [*] to me'
+    'Syntax error: Piped optionals can\'t include blank entries at stream() line 7 near + cat [*] [mild|warm||hot] [*] to me'
+  ]
+
+  console.error = (text)->
+    errors.push(text)
+
+  bot = new TestCase(test, """
+    + bot [*] [hi|hey|sup|yo|] [*] to me
+    - Oh hello there.
+
+    + dog [*] [|good|great|nice] [*] to me
+    - Oh nice!
+
+    + cat [*] [mild|warm||hot] [*] to me
+    - Purrfect.
+
+    + *
+    - Anything else?
+  """)
+
+  # Check that errors were thrown
+  test.deepEqual(errors, expected_errors)
+
+  # We also fix these, so these should also work
+  bot.reply("Bot say hey to me", "Oh hello there.")
+  bot.reply("bot w hi to me", "Oh hello there.")
+  bot.reply("dog be nice to me", "Oh nice!")
+  bot.reply("Dog don't be good to me", "Oh nice!")
+  bot.reply("Cat should not feel warm to me", "Purrfect.")
   bot.reply("Bye!", "Anything else?")
   bot.reply("Love you", "Anything else?")
   test.done()


### PR DESCRIPTION
This pull requests fixes #100, which is for when empty entities exist in array, alternations, or optionals. Previously, having an empty entity would cause matching issues that would essentially match on any given case. This will now filter out known empty entities in triggers, previous and array variables.

PR also includes validation warnings for when arrays, alternations, or optionals contain empty entities in beginning, middle, or end. 

Tests for both filtering and proper validation warnings are included with this request.