### PR TITLE
Fix line breaks ruining call tag regexp

### DIFF
--- a/docs/html/utils.html
+++ b/docs/html/utils.html
@@ -10,6 +10,10 @@
 <h2>string strip (string)</h2>
 <p>Strip extra whitespace from both ends of the string, and remove
 line breaks anywhere in the string.</p>
+<h2>string trim (string)</h2>
+<p>Compatible implementation of <code>String.prototype.trim()</code>. Strips whitespace
+from the beginning and end of the string, but doesn't remove any
+whitespace inside the string like <code>strip()</code> does.</p>
 <h2>void extend (object a, object b)</h2>
 <p>Combine the properties of both objects into one. The properties from
 object 'b' are inserted into 'a'.</p>

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -5,6 +5,12 @@
 Strip extra whitespace from both ends of the string, and remove
 line breaks anywhere in the string.
 
+## string trim (string)
+
+Compatible implementation of `String.prototype.trim()`. Strips whitespace
+from the beginning and end of the string, but doesn't remove any
+whitespace inside the string like `strip()` does.
+
 ## void extend (object a, object b)
 
 Combine the properties of both objects into one. The properties from

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -91,7 +91,7 @@ class Brain
   processCallTags: (reply, scope, async) ->
     reply = reply.replace(/\{__call__\}/g, "<call>")
     reply = reply.replace(/\{\/__call__\}/g, "</call>")
-    callRe = /<call>(.+?)<\/call>/ig
+    callRe = /<call>([\s\S]+?)<\/call>/ig
     argsRe = /{__call_arg__}([^{]*){\/__call_arg__}/ig
 
     giveup = 0
@@ -109,7 +109,7 @@ class Brain
       if not match
         break
 
-      text  = utils.strip(match[1])
+      text = utils.trim(match[1])
 
       # get subroutine name
       subroutineNameMatch = (/(\S+)/ig).exec(text)

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -18,7 +18,19 @@
 exports.strip = (text) ->
   text = text.replace(/^[\s\t]+/, "") \
              .replace(/[\s\t]+$/, "") \
-             .replace(/[\x0D\x0A]+/, "");
+             .replace(/[\x0D\x0A]+/, "")
+  return text
+
+##
+# string trim (string)
+#
+# Compatible implementation of `String.prototype.trim()`. Strips whitespace
+# from the beginning and end of the string, but doesn't remove any
+# whitespace inside the string like `strip()` does.
+##
+exports.trim = (text) ->
+  text = text.replace(/^[\x0D\x0A\s\t]+/, "") \
+             .replace(/[\x0D\x0A\s\t]+$/, "")
   return text
 
 ##
@@ -138,7 +150,7 @@ exports.clone = (obj) ->
 # Determines if obj looks like a promise
 ##
 exports.isAPromise = (obj) ->
-  return obj and obj.then and obj.catch and obj.finally and 
-  typeof obj.then is 'function' and 
+  return obj and obj.then and obj.catch and obj.finally and
+  typeof obj.then is 'function' and
   typeof obj.catch is 'function' and
-  typeof obj.finally is 'function' 
+  typeof obj.finally is 'function'


### PR DESCRIPTION
Per issue #108, if you used a line break sequence "\n" inside a `<call>` tag, it would break the regular expression trying to match the `<call>...</call>` sequence because this regexp couldn't handle line breaks.

JavaScript regexp doesn't support the `/.../s` flag which would make the `.` metacharacter match line break characters. The workaround is to replace the `.` metacharacter with the sequence `[\s\S]` to match spaces and non-space characters (essentially forcing it to match everything, including line breaks).

```diff
- callRe = /<call>(.+?)<\/call>/ig
+ callRe = /<call>([\s\S]+?)<\/call>/ig
```

Additionally, I changed the code to call the new `utils.trim()` function (which is a more compatible version of `String.prototype.trim()` to support Internet Explorer < 9) instead of the `utils.strip()` function -- because that function would remove line breaks *anywhere* in a string, negating the whole point of allowing "\n" to appear inside a `<call>` tag.

This code fixes #108.