### PR TITLE
Add `initialMatch()` feature

### DIFF
--- a/docs/html/rivescript.html
+++ b/docs/html/rivescript.html
@@ -206,6 +206,10 @@ entire variable state, so that it can be restored later with
 * thaw: Restore the variables and delete the frozen copy (default)</p>
 <h2>string lastMatch (string user)</h2>
 <p>Retrieve the trigger that the user matched most recently.</p>
+<h2>string initialMatch (string user)</h2>
+<p>Retrieve the trigger that the user matched initially. This will return
+only the first matched trigger and will not include subsequent redirects.</p>
+<p>This value is reset on each <code>reply()</code> or <code>replyAsync()</code> call.</p>
 <h2>string currentUser ()</h2>
 <p>Retrieve the current user's ID. This is most useful within a JavaScript
 object macro to get the ID of the user who invoked the macro (e.g. to

--- a/docs/rivescript.md
+++ b/docs/rivescript.md
@@ -291,6 +291,13 @@ Thaw a user's frozen variables. The action can be one of the following:
 
 Retrieve the trigger that the user matched most recently.
 
+## string initialMatch (string user)
+
+Retrieve the trigger that the user matched initially. This will return
+only the first matched trigger and will not include subsequent redirects.
+
+This value is reset on each `reply()` or `replyAsync()` call.
+
 ## string currentUser ()
 
 Retrieve the current user's ID. This is most useful within a JavaScript

--- a/eg/json-server/README.md
+++ b/eg/json-server/README.md
@@ -121,7 +121,8 @@ Connection: keep-alive
                 "undefined"
             ]
         },
-        "__lastmatch__": "(hello|hi|hey|howdy|hola|hai|yo) [*]"
+        "__lastmatch__": "(hello|hi|hey|howdy|hola|hai|yo) [*]",
+        "__initialmatch__": "(hello|hi|hey|howdy|hola|hai|yo) [*]"
     }
 }
 ```

--- a/eg/persistence/README.md
+++ b/eg/persistence/README.md
@@ -85,6 +85,7 @@ after your username. Example:
     ]
   },
   "__lastmatch__": "(what is my name|who am i|do you know my name|do you know who i am){weight=10}",
+  "__initialmatch__": "(what is my name|who am i|do you know my name|do you know who i am){weight=10}",
   "name": "Noah"
 }
 ```

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -47,6 +47,10 @@ class Brain
     msg   = @formatMessage(msg)
     reply = ""
 
+    # Set initial match to be undefined
+    if @master.getUservars(user)
+      @master._users[user].__initialmatch__ = undefined
+
     # If the BEGIN block exists, consult it first.
     if @master._topics.__begin__
       begin = @_getReply(user, "request", "begin", 0, scope)
@@ -417,6 +421,10 @@ class Brain
     # Store what trigger they matched on. If their matched trigger is undefined,
     # this will be too, which is great.
     @master._users[user].__lastmatch__ = matchedTrigger
+
+    # Store initial matched trigger. Like __lastmatch__, this can be undefined.
+    if step is 0
+      @master._users[user].__initialmatch__ = matchedTrigger
 
     # Did we match?
     if matched

--- a/src/rivescript.coffee
+++ b/src/rivescript.coffee
@@ -826,6 +826,19 @@ class RiveScript
     return undefined
 
   ##
+  # string initialMatch (string user)
+  #
+  # Retrieve the trigger that the user matched initially. This will return
+  # only the first matched trigger and will not include subsequent redirects.
+  #
+  # This value is reset on each `reply()` or `replyAsync()` call.
+  ##
+  initialMatch: (user) ->
+    if @_users[user]?
+      return @_users[user].__initialmatch__
+    return undefined
+
+  ##
   # string currentUser ()
   #
   # Retrieve the current user's ID. This is most useful within a JavaScript

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -172,3 +172,39 @@ exports.test_redirect_with_undefined_input = (test) ->
 
 
   test.done()
+
+exports.test_initialmatch = (test) ->
+  bot = new TestCase(test, """
+    ! array thanks = thanks|thank you
+
+    + (hello|ni hao)
+    @ hi
+
+    + hi
+    - Oh hi. {@phrase}
+
+    + phrase
+    - How are you?
+
+    + good
+    - That's great.
+
+    + @thanks{weight=2}
+    - No problem. {@phrase}
+
+    + *
+    - I don't know.
+  """)
+  bot.reply("Hello?", "Oh hi. How are you?")
+  bot.uservar("__lastmatch__", "phrase")
+  bot.uservar("__initialmatch__", "(hello|ni hao)")
+
+  bot.reply("Good!", "That's great.")
+  bot.uservar("__lastmatch__", "good")
+  bot.uservar("__initialmatch__", "good")
+
+  bot.reply("Thanks!", "No problem. How are you?")
+  bot.uservar("__lastmatch__", "phrase")
+  bot.uservar("__initialmatch__", "@thanks{weight=2}")
+
+  test.done()


### PR DESCRIPTION
Adding initialMatch() and `__initialmatch__` features too track the initial trigger that the brain evaluated. Unlike `__lastmatch__`, `__initialmatch__` will only be set on the first evaluation and not change on subsequent redirects. `__initialmatch__` will reset on each reply() or replyAsync() request.

This PR includes a initialMatch() function to easily fetch the value of `__initialmatch__`.

Includes passing tests and updated docs. (And is current w/ upstream!)