### PR TITLE
Fix underscore wildcards not matching Unicode letters

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,6 @@
 # Changes
 
-* 1.13.0 TBD
+* 1.13.0 2016-06-14
   - Fix the `<call>` tags not being executed on the left side of conditionals,
     so that `<call>test</call> == true => Success` types of conditions should
     work (bug #107).
@@ -8,6 +8,9 @@
     before or after it (or: a space between `{weight}` and the rest of the
     trigger text), the spaces are also stripped so that matching isn't broken
     for that trigger (bug #102).
+  - Rename the old `async-object` example to `second-reply` to lessen confusion
+    between it and `async-reply` (bug #123).
+  - Fix the `_` wildcard not being able to match Unicode letters (bug #118).
 
 * 1.12.2 2016-05-16
   - Call the error handler on `loadDirectory()` when the directory doesn't exist

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -666,9 +666,11 @@ class Brain
 
     # _ wildcards can't match numbers! Quick note on why I did it this way:
     # the initial replacement above (_ => (\w+?)) needs to be \w because the
-    # square brackets in [A-Za-z] will confuse the optionals logic just above.
-    # So then we switch it back down here.
-    regexp = regexp.replace(/\\w/, "[A-Za-z]")
+    # square brackets in [\s\d] will confuse the optionals logic just above.
+    # So then we switch it back down here. Also, we don't just use \w+ because
+    # that matches digits, and similarly [A-Za-z] doesn't work with Unicode,
+    # so this regexp excludes spaces and digits instead of including letters.
+    regexp = regexp.replace(/\\w/, "[^\\s\\d]")
 
     # Filter in arrays.
     giveup = 0

--- a/test/test-unicode.coffee
+++ b/test/test-unicode.coffee
@@ -54,6 +54,26 @@ exports.test_unicode = (test) ->
   bot.reply("more", "Änd thät wäs thë ënd öf hïm.")
   test.done()
 
+exports.test_wildcards = (test) ->
+  bot = new TestCase(test, """
+    + my name is _
+    - Nice to meet you, <star>.
+
+    + i am # years old
+    - A lot of people are <star> years old.
+
+    + *
+    - No match.
+  """, {utf8: true})
+
+  bot.reply("My name is Aiden", "Nice to meet you, aiden.")
+  bot.reply("My name is Bảo", "Nice to meet you, bảo.")
+  bot.reply("My name is 5", "No match.")
+
+  bot.reply("I am five years old", "No match.")
+  bot.reply("I am 5 years old", "A lot of people are 5 years old.")
+  test.done()
+
 exports.test_punctuation = (test) ->
   bot = new TestCase(test, """
     + hello bot


### PR DESCRIPTION
This fixes #118 by changing the `[A-Za-z]+` regexp to `[^\s\d]+` to match all Unicode letters while still excluding numbers and spaces (as was the original intention of the `_` wildcard).