### PR TITLE
Add a router example

### DIFF
--- a/eg/README.md
+++ b/eg/README.md
@@ -39,3 +39,7 @@ RiveScript-js.
 * [coffeescript](coffeescript/) - Example of using the
   `rivescript-contrib-coffeescript` module to enable CoffeeScript language for
   object macros.
+* [router](router/) - Example of using the RiveScript engine in a "router"
+  style way (in the web application sense of the term), mapping triggers
+  directly to JavaScript handlers without writing RiveScript boilerplate for
+  each mapping.

--- a/eg/router/README.md
+++ b/eg/router/README.md
@@ -1,0 +1,125 @@
+# RiveScript as a Router
+
+This example was created in response to the discussion in
+[Issue #130](https://github.com/aichaos/rivescript-js/issues/130) about using
+RiveScript as a router (in the web application sense of the word).
+
+In web applications, you define routes (URIs) and function handlers to be called
+when a browser requests that route.
+
+```javascript
+app.route("/myRoute", Class.method);
+```
+
+If you're writing a very heavily programmatic chatbot, where you want JavaScript
+object macro handlers for *many, many* triggers, and you don't want to keep
+writing out `<call>` commands over and over again, this example offers an idea
+for doing this in a [D.R.Y.](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)
+way.
+
+## Concepts Demonstrated
+
+This example covers multiple useful things:
+
+* JavaScript object macros that import an external module (`controllers.js`),
+  without needing to repeatedly `require()` them every single time in every
+  macro handler.
+* Defining triggers that directly map to your object macros without needing to
+  manually re-write the `<call>` tags multiple times.
+* Using the RiveScript engine (with its simplified regexp triggers and its
+  sorting algorithm) *without* actually writing a single line of RiveScript
+  code by hand.
+
+This example doesn't cover, but it is possible, mixing a router-style approach
+with normal RiveScript replies. For example, separately from all the code that
+registers "routes" to handlers you could include a normal `loadFile()` or
+`loadDirectory()` call, and load normal RiveScript sources that have their own
+normal replies with them instead of needing to call function handlers for every
+message.
+
+## Run the Example
+
+To run this, first run `grunt dist` from the root of the rivescript-js project
+(to build the JavaScript code from the CoffeeScript sources for RiveScript),
+and then run `node router.js`:
+
+```bash
+[rivescript-js]$ grunt dist
+[rivescript-js]$ cd eg/router
+[router]$ node router.js
+```
+
+Example output:
+
+```
+% node router.js
+Note: type `/quit` to exit.
+You> hello bot
+[Captain's Log] Unhandled message: hello bot
+Bot> No reply for that one. Try one of these:
+   add 5 and 7
+   what is 12 divided by 3
+   reverse hello world
+   say hi robot to me backwards
+You> add 5 and 7
+Bot> 12
+You> reverse how are you?
+Bot> uoy era woh
+You> say hi robot to me backwards
+Bot> tobor ih
+```
+
+## How it Works
+
+Review the source of `router.js`, the entry point to this example bot.
+
+The `replies` object is where most of the magic happens. It creates simple
+arrays of just the trigger texts, and associates them with a JavaScript
+function to be called when one of those triggers is matched. The actual
+implementations of the two functions exposed (`math` and `reverse`) are in
+`controllers.js`, which is an external Node module, and this demonstrates that
+a module imported *once* in the global scope can be made available to the
+individual object macros without each of them needing to import their own
+copies.
+
+At the bottom of `router.js` is some "write once" boilerplate that iterates
+through the `replies` object and dynamically creates RiveScript source code
+and registers the JavaScript object macros.
+
+The dynamically generated RiveScript source is loaded by the bot using the
+`stream()` function, which allows you to import RiveScript source from a string
+rather than a file. This way, the bot writer doesn't actually need to write a
+single line of raw RiveScript code herself. An example of the dynamically
+generated RiveScript code looks like this:
+
+```
++ [*] what is # * [by|to|and] #
+- <call>math "<star1>" "<star2>" "<star3>"</call>
+```
+
+But you don't ever actually write that code out yourself!
+
+The router example then enters a readline loop, similar to the `shell.js` at
+the root of the RiveScript-JS project, to enable chatting with the bot using
+your terminal.
+
+## Available Functions
+
+For this example, we make three functions available: `math`, `reverse`, and
+`wildcard`. Here are examples of how to invoke these with your messages:
+
+* `math`
+  * `add 5 and 7`
+  * `what is 12 divided by 3`
+  * `what is 4 times 8`
+  * `what is 6 multiplied by 12`
+  * `subtract 13 by 4`
+* `reverse`
+  * `say hello to me backwards`
+  * `reverse rivescript`
+  * `say how are you in reverse`
+* `wildcard`
+  * Literally any message that doesn't match the other patterns.
+
+The wildcard handler matches all uncaught messages (`*`), and gives you examples
+of messages to try the other handlers.

--- a/eg/router/controllers.js
+++ b/eg/router/controllers.js
@@ -1,0 +1,54 @@
+// This controllers module serves as an example for how multiple object
+// macros can effectively do `require("./controllers")` without actually
+// needing to keep importing it over and over again.
+
+// Instead, the main bot program (`router.js`) imports this module one time,
+// and defines all the object macros via `setSubroutine()` so they all have
+// access to the global scope and can use the methods in this module.
+
+// doMath takes a math operation and two numbers.
+module.exports.doMath = function(oper, a, b) {
+	a = parseFloat(a), b = parseFloat(b);
+
+	if (oper.match(/^divided?$/)) {
+		if (b != 0) {
+			return a / b;
+		}
+		else {
+			return "Zero divison error.";
+		}
+	}
+	else if (oper.match(/^(multipl(?:ied|y)?|times)$/)) {
+		return a * b;
+	}
+	else if (oper.match(/^add(?:ed)?$/)) {
+		return a + b;
+	}
+	else if (oper.match(/^(subtract(?:ed)?|minus)$/)) {
+		return a - b;
+	}
+	else {
+		return "I don't know how to '" + oper + "' those numbers.";
+	}
+};
+
+// doReverse takes a string of text and reverses it.
+module.exports.doReverse = function(text) {
+	return text.split("").reverse().join("");
+};
+
+// doWildcard suggests other messages for the user to try.
+module.exports.doWildcard = function(rs, args) {
+	var text = args.join(" ");
+
+	// You could log the uncaught message somewhere to give the botmaster
+	// some tips for new triggers to cover.
+	console.log("[Captain's Log] Unhandled message: " + text);
+
+	// Return a list of suggested messages for the user to try.
+	return "No reply for that one. Try one of these:\n" +
+		"   add 5 and 7\n" +
+		"   what is 12 divided by 3\n" +
+		"   reverse hello world\n" +
+		"   say hi robot to me backwards";
+}

--- a/eg/router/router.js
+++ b/eg/router/router.js
@@ -1,0 +1,126 @@
+// Example of using RiveScript as a router.
+//
+// See the README.md for information.
+
+var RiveScript = require("../../lib/rivescript"),
+	readline = require("readline");
+
+// Import an external module that the object macros may use.
+var Controllers = require("./controllers");
+
+// This is our data structure where we map triggers into object macro
+// functions. This is just one way you could organize your program.
+var replies = {
+	// The top-level keys are named after the object macro that handles
+	// the triggers.
+	math: {
+		// List of triggers that will route to this macro
+		triggers: [
+			"[*] what is # * [by|to|and] #",
+			"[*] * # [by|to|from|and] #"
+		],
+
+		// The args for the `<call>` tag: we send all the captured
+		// wildcards into the object macro.
+		args: '"<star1>" "<star2>" "<star3>"',
+
+		// The object macro function itself.
+		handler: function(rs, args) {
+			// This function is invoked by messages such as:
+			//   what is 5 subtracted by 2
+			//   add 6 to 7
+			if (args[0].match(/^\d+$/)) {
+				// They used the first form, with a number.
+				return Controllers.doMath(args[1], args[0], args[2]);
+			}
+			else {
+				// The second form, first word being the operation.
+				return Controllers.doMath(args[0], args[1], args[2]);
+			}
+		}
+	},
+
+	// Another example, for completion's sake.
+	reverse: {
+		triggers: [
+			"say * in reverse",
+			"say * to me (backward|backwards|in reverse|reversed)",
+			"reverse *"
+		],
+		args: "<star1>",
+		handler: function(rs, args) {
+			var text = args.join(" ");
+
+			// Another example of using that imported module.
+			var reversed = Controllers.doReverse(text);
+
+			return reversed;
+		}
+	},
+
+	// If you want your wildcard `*` trigger to be dynamically handled too.
+	// Also note that this one *directly* uses our controller function as the
+	// object macro, if you like that way of routing triggers instead of
+	// defining all your inline functions here.
+	wildcard: {
+		triggers: ["*"],
+		args: "<star>",
+		handler: Controllers.doWildcard
+	}
+}
+
+// Now with all your triggers ("routes") and handlers configured as in the
+// above, we can programmatically load them into RiveScript: both the object
+// macro handlers themselves, and the triggers that `<call>` those macros.
+//
+// This part of the code wouldn't change even as you add more triggers and
+// handlers in the above structure.
+var rs = new RiveScript({utf8: true});
+for (var callable in replies) {
+	if (!replies.hasOwnProperty(callable)) continue;
+
+	// Map the trigger texts to the `<call>` command for the callable.
+	for (var i in replies[callable].triggers) {
+		rs.stream("+ " + replies[callable].triggers[i] + "\n"
+			+ "- <call>" + callable + " " + replies[callable].args + "</call>\n"
+		);
+	}
+
+	// Register the JavaScript object macro.
+	rs.setSubroutine(callable, replies[callable].handler);
+}
+
+// If you wanted to combine the above router-controller style system with
+// a "normal" RiveScript bot (using normal .rive files from disk), you could
+// easily insert your own `rs.loadFile()` or `rs.loadDirectory()` calls around
+// this part of the source. This example wants to stay "pure" and doesn't
+// include any "normal" replies, but the two approaches can be mixed and matched
+// with no problems!
+
+// Finally, sort all those dynamically passed triggers.
+rs.sortReplies();
+
+// For this example, we'll chat with the bot in the terminal, so start a
+// readline loop for the interactive session (like in shell.js):
+console.log("Note: type `/quit` to exit.");
+var rl = readline.createInterface({
+	input: process.stdin,
+	output: process.stdout
+});
+
+rl.setPrompt("You> ");
+rl.prompt();
+rl.on("line", function(cmd) {
+	// Handle commands.
+	if (cmd === "/quit") {
+		process.exit(0);
+	} else {
+		// Get a reply from the bot.
+		var reply = rs.reply("localuser", cmd);
+		console.log("Bot>", reply);
+	}
+
+	rl.prompt();
+}).on("close", function() {
+	process.exit(0);
+});


### PR DESCRIPTION
The discussion in #130 of using RiveScript as a router-controller system was somewhat interesting and I wrote an example bot that demonstrates how someone could set up such a system using RiveScript.

This adds `eg/router` to the list of examples.