### PR TITLE
Add support for third party session handlers

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -19,6 +19,7 @@ The internal reply method. DO NOT CALL THIS DIRECTLY.
 * user, msg and scope are the same as reply()
 * context = "normal" or "begin"
 * step = the recursion depth
+* scope = the call scope for object macros
 
 ## string formatMessage (string msg)
 

--- a/docs/html/brain.html
+++ b/docs/html/brain.html
@@ -20,6 +20,7 @@ and it returns a promise, otherwise a string is returned</p>
 <li>user, msg and scope are the same as reply()</li>
 <li>context = "normal" or "begin"</li>
 <li>step = the recursion depth</li>
+<li>scope = the call scope for object macros</li>
 </ul>
 <h2>string formatMessage (string msg)</h2>
 <p>Format a user's message for safe processing.</p>

--- a/docs/html/rivescript.html
+++ b/docs/html/rivescript.html
@@ -10,12 +10,16 @@
 <p>Create a new RiveScript interpreter. <code>options</code> is an object with the
 following keys:</p>
 <ul>
-<li>bool debug:    Debug mode            (default false)</li>
-<li>int  depth:    Recursion depth limit (default 50)</li>
-<li>bool strict:   Strict mode           (default true)</li>
-<li>bool utf8:     Enable UTF-8 mode     (default false)</li>
-<li>func onDebug:  Set a custom handler to catch debug log messages (default null)</li>
-<li>obj  errors:   Customize certain error messages (see below)</li>
+<li>bool debug: Debug mode            (default false)</li>
+<li>int  depth: Recursion depth limit (default 50)</li>
+<li>bool strict: Strict mode           (default true)</li>
+<li>bool utf8: Enable UTF-8 mode     (default false)</li>
+<li>func onDebug: Set a custom handler to catch debug log messages (default null)</li>
+<li>obj errors: Customize certain error messages (see below)</li>
+<li>obj sessionHandler: Provide a custom session handler for managing user
+  variables (default is to keep them all in memory). See the
+  <a href="https://github.com/aichaos/rivescript-js/blob/master/docs/sessions.md">sessions documentation</a>
+  for more information.</li>
 </ul>
 <h2>UTF-8 Mode</h2>
 <p>In UTF-8 mode, most characters in a user's message are left intact, except for

--- a/docs/html/sessions.html
+++ b/docs/html/sessions.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>sessions</title>
+<link rel="stylesheet" type="text/css" href="md.css">
+</head>
+<body>
+
+<h1>SessionHandler</h1>
+<p>This is the default session manager used by RiveScript to store and retrieve
+user variables. This session handler just keeps the variables in RAM; if you
+want to provide your own session handler (e.g. to use a database), you can
+program your own handler and pass it into the RiveScript constructor:</p>
+<pre class="codehilite"><code class="language-javascript">var bot = new RiveScript({
+    sessionHandler: new MySessionHandler()
+})</code></pre>
+
+
+<p>Your custom session handler should be a JavaScript object (class) that
+implements the following functions:</p>
+<ul>
+<li>void set (string username, object vars): For setting user variables. The
+  <code>vars</code> object is a key/value dictionary mapping user variable names (key)
+  to their values. The values will usually be strings, but can be other types
+  for some internal data structures (e.g. input/reply histories as arrays).</li>
+<li>string get (string username, [string key]): For retrieving a user variable.
+  Return the string <code>"undefined"</code> if the variable doesn't exist. If the <code>key</code>
+  parameter is not provided, this should instead return the full object of
+  key/value pairs for the user.</li>
+<li>object getAll(): Retrieve all user variables for all users. This should
+  return an object where the top-level key is the username, and the values
+  are objects of key/value pairs of that user's variables.</li>
+<li>void reset (string username): This should delete all variables about the
+  given username.</li>
+<li>void resetAll(): This should delete all variables about all users.</li>
+<li>void freeze (string username): Make a snapshot of a user's variables, which
+  can be later restored using <code>thaw()</code>.</li>
+<li>void thaw (string username[, string action]): Restore a user's variables
+  from the frozen snapshot. This should replace <em>all</em> their variables with the
+  set that was frozen. The valid options for <code>action</code> are:</li>
+<li><code>thaw</code>: Restore the variables and delete the frozen copy (default).</li>
+<li><code>discard</code>: Don't restore the variables, just delete the frozen copy.</li>
+<li><code>keep</code>: After restoring the user's variables, keep the frozen copy around
+    anyway (e.g. so future calls to <code>thaw()</code> will keep restoring the same
+    set of variables).</li>
+</ul>
+<p>All class methods are optional, and RiveScript won't attempt to call them if
+they haven't been implemented.</p>
+
+</body>
+</html>

--- a/docs/rivescript.md
+++ b/docs/rivescript.md
@@ -3,12 +3,16 @@
 Create a new RiveScript interpreter. `options` is an object with the
 following keys:
 
-* bool debug:    Debug mode            (default false)
-* int  depth:    Recursion depth limit (default 50)
-* bool strict:   Strict mode           (default true)
-* bool utf8:     Enable UTF-8 mode     (default false)
-* func onDebug:  Set a custom handler to catch debug log messages (default null)
-* obj  errors:   Customize certain error messages (see below)
+* bool debug: Debug mode            (default false)
+* int  depth: Recursion depth limit (default 50)
+* bool strict: Strict mode           (default true)
+* bool utf8: Enable UTF-8 mode     (default false)
+* func onDebug: Set a custom handler to catch debug log messages (default null)
+* obj errors: Customize certain error messages (see below)
+* obj sessionHandler: Provide a custom session handler for managing user
+  variables (default is to keep them all in memory). See the
+  [sessions documentation](https://github.com/aichaos/rivescript-js/blob/master/docs/sessions.md)
+  for more information.
 
 ## UTF-8 Mode
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,43 @@
+# SessionHandler
+
+This is the default session manager used by RiveScript to store and retrieve
+user variables. This session handler just keeps the variables in RAM; if you
+want to provide your own session handler (e.g. to use a database), you can
+program your own handler and pass it into the RiveScript constructor:
+
+```javascript
+var bot = new RiveScript({
+    sessionHandler: new MySessionHandler()
+})
+```
+
+Your custom session handler should be a JavaScript object (class) that
+implements the following functions:
+
+* void set (string username, object vars): For setting user variables. The
+  `vars` object is a key/value dictionary mapping user variable names (key)
+  to their values. The values will usually be strings, but can be other types
+  for some internal data structures (e.g. input/reply histories as arrays).
+* string get (string username, [string key]): For retrieving a user variable.
+  Return the string `"undefined"` if the variable doesn't exist. If the `key`
+  parameter is not provided, this should instead return the full object of
+  key/value pairs for the user.
+* object getAll(): Retrieve all user variables for all users. This should
+  return an object where the top-level key is the username, and the values
+  are objects of key/value pairs of that user's variables.
+* void reset (string username): This should delete all variables about the
+  given username.
+* void resetAll(): This should delete all variables about all users.
+* void freeze (string username): Make a snapshot of a user's variables, which
+  can be later restored using `thaw()`.
+* void thaw (string username[, string action]): Restore a user's variables
+  from the frozen snapshot. This should replace *all* their variables with the
+  set that was frozen. The valid options for `action` are:
+  * `thaw`: Restore the variables and delete the frozen copy (default).
+  * `discard`: Don't restore the variables, just delete the frozen copy.
+  * `keep`: After restoring the user's variables, keep the frozen copy around
+    anyway (e.g. so future calls to `thaw()` will keep restoring the same
+    set of variables).
+
+All class methods are optional, and RiveScript won't attempt to call them if
+they haven't been implemented.

--- a/package.json
+++ b/package.json
@@ -40,12 +40,7 @@
     "Philip Nuzhnyi (https://github.com/callmephilip)",
     "pirelaurent (https://github.com/pirelaurent)"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/aichaos/rivescript-js/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/aichaos/rivescript-js/issues",
     "email": "root@kirsle.net"

--- a/src/rivescript.coffee
+++ b/src/rivescript.coffee
@@ -10,9 +10,10 @@
 VERSION  = "1.13.0"
 
 # Helper modules
-Parser  = require "./parser"
-Brain   = require "./brain"
-utils   = require "./utils"
+Parser = require "./parser"
+Brain = require "./brain"
+SessionHandler = require "./sessions"
+utils = require "./utils"
 sorting = require "./sorting"
 inherit_utils = require "./inheritance"
 JSObjectHandler = require "./lang/javascript"
@@ -25,12 +26,16 @@ readDir = require("fs-readdir-recursive")
 # Create a new RiveScript interpreter. `options` is an object with the
 # following keys:
 #
-# * bool debug:    Debug mode            (default false)
-# * int  depth:    Recursion depth limit (default 50)
-# * bool strict:   Strict mode           (default true)
-# * bool utf8:     Enable UTF-8 mode     (default false)
-# * func onDebug:  Set a custom handler to catch debug log messages (default null)
-# * obj  errors:   Customize certain error messages (see below)
+# * bool debug: Debug mode            (default false)
+# * int  depth: Recursion depth limit (default 50)
+# * bool strict: Strict mode           (default true)
+# * bool utf8: Enable UTF-8 mode     (default false)
+# * func onDebug: Set a custom handler to catch debug log messages (default null)
+# * obj errors: Customize certain error messages (see below)
+# * obj sessionHandler: Provide a custom session handler for managing user
+#   variables (default is to keep them all in memory). See the
+#   [sessions documentation](https://github.com/aichaos/rivescript-js/blob/master/docs/sessions.md)
+#   for more information.
 #
 # ## UTF-8 Mode
 #
@@ -140,6 +145,9 @@ class RiveScript
         if opts.errors.hasOwnProperty(key)
           @errors[key] = value
 
+    # The session handler.
+    @_sessionHandler = if opts.sessionHandler then opts.sessionHandler else new SessionHandler({warn: @warn})
+
     # Identify our runtime environment. Web, or node?
     @_node    = {} # NodeJS objects
     @_runtime = @runtime()
@@ -160,8 +168,6 @@ class RiveScript
     @_sub      = {} # 'sub' substitutions
     @_person   = {} # 'person' substitutions
     @_array    = {} # 'array' variables
-    @_users    = {} # 'user' variables
-    @_freeze   = {} # frozen 'user' variables
     @_includes = {} # included topics
     @_inherits = {} # inherited topics
     @_handlers = {} # object handlers
@@ -689,14 +695,10 @@ class RiveScript
   # Set a user variable for a user.
   ##
   setUservar: (user, name, value) ->
-    # Initialize the user?
-    if not @_users[user]
-      @_users[user] = {topic: "random"}
-
-    if value is undefined
-      delete @_users[user][name]
-    else
-      @_users[user][name] = value
+    if @_sessionHandler.set?
+      inbound = {}
+      inbound[name] = value
+      @_sessionHandler.set user, inbound
 
   ##
   # void setUservars (string user, object data)
@@ -705,16 +707,8 @@ class RiveScript
   # Equivalent to calling `setUservar()` for each pair in the object.
   ##
   setUservars: (user, data) ->
-    # Initialize the user?
-    if not @_users[user]
-      @_users[user] = {topic: "random"}
-
-    for key of data
-      continue unless data.hasOwnProperty key
-      if data[key] is undefined
-        delete @_users[user][key]
-      else
-        @_users[user][key] = data[key]
+    if @_sessionHandler.set?
+      @_sessionHandler.set user, data
 
   ##
   # void getVariable (string name)
@@ -735,15 +729,8 @@ class RiveScript
   # defined.
   ##
   getUservar: (user, name) ->
-    # No user?
-    if not @_users[user]
-      return "undefined"
-
-    # The var exists?
-    if typeof(@_users[user][name]) isnt "undefined"
-      return @_users[user][name]
-    else
-      return "undefined"
+    if @_sessionHandler.get?
+      return @_sessionHandler.get(user, name)
 
   ##
   # data getUservars ([string user])
@@ -752,13 +739,10 @@ class RiveScript
   # about all users.
   ##
   getUservars: (user) ->
-    if user is undefined
-      # All the users! Return a cloned object to break refs.
-      return utils.clone(@_users)
-    else
-      if @_users[user]?
-        return utils.clone(@_users[user])
-      return undefined
+    if user is undefined and @_sessionHandler.getAll?
+      return @_sessionHandler.getAll()
+    else if user isnt undefined and @_sessionHandler.get?
+      return @_sessionHandler.get user
 
   ##
   # void clearUservars ([string user])
@@ -767,10 +751,10 @@ class RiveScript
   # for all users.
   ##
   clearUservars: (user) ->
-    if user is undefined
-      @_users = {}
-    else
-      delete @_users[user]
+    if user is undefined and @_sessionHandler.resetAll?
+      @_sessionHandler.resetAll()
+    else if user isnt undefined and @_sessionHandler.reset?
+      @_sessionHandler.reset()
 
   ##
   # void freezeUservars (string user)
@@ -780,10 +764,8 @@ class RiveScript
   # `thawUservars()`
   ##
   freezeUservars: (user) ->
-    if @_users[user]?
-      @_freeze[user] = utils.clone(@_users[user])
-    else
-      @warn "Can't freeze vars for user #{user}: not found!"
+    if @_sessionHandler.freeze?
+      @_sessionHandler.freeze user
 
   ##
   # void thawUservars (string user[, string action])
@@ -794,26 +776,8 @@ class RiveScript
   # * thaw: Restore the variables and delete the frozen copy (default)
   ##
   thawUservars: (user, action="thaw") ->
-    if typeof(action) isnt "string"
-      action = "thaw"
-
-    # Frozen?
-    if not @_freeze[user]?
-      @warn "Can't thaw user vars: #{user} wasn't frozen!"
-      return
-
-    # What are we doing?
-    if action is "thaw"
-      @clearUservars(user)
-      @_users[user] = utils.clone(@_freeze[user])
-      delete @_freeze[user]
-    else if action is "discard"
-      delete @_freeze[user]
-    else if action is "keep"
-      @clearUservars(user)
-      @_users[user] = utils.clone(@_freeze[user])
-    else
-      @warn "Unsupported thaw action!"
+    if @_sessionHandler.thaw?
+      @_sessionHandler.thaw(user, action)
 
   ##
   # string lastMatch (string user)
@@ -821,9 +785,7 @@ class RiveScript
   # Retrieve the trigger that the user matched most recently.
   ##
   lastMatch: (user) ->
-    if @_users[user]?
-      return @_users[user].__lastmatch__
-    return undefined
+    return @getUservar(user, "__lastmatch__")
 
   ##
   # string initialMatch (string user)
@@ -834,9 +796,7 @@ class RiveScript
   # This value is reset on each `reply()` or `replyAsync()` call.
   ##
   initialMatch: (user) ->
-    if @_users[user]?
-      return @_users[user].__initialmatch__
-    return undefined
+    return @getUservar(user, "__initialmatch__")
 
   ##
   # string currentUser ()

--- a/src/sessions.coffee
+++ b/src/sessions.coffee
@@ -54,11 +54,11 @@ utils = require "./utils"
 ##
 
 class SessionHandler
-  constructor: (warn) ->
+  constructor: (opts) ->
     # In-memory user variable store.
     @_store  = {}
     @_freeze = {}
-    @warn    = warn
+    @warn    = opts?.warn
 
   set: (username, vars) ->
     # Initialize the user?

--- a/src/sessions.coffee
+++ b/src/sessions.coffee
@@ -1,0 +1,130 @@
+# RiveScript.js
+#
+# This code is released under the MIT License.
+# See the "LICENSE" file for more information.
+#
+# http://www.rivescript.com/
+
+utils = require "./utils"
+
+##
+# SessionHandler
+#
+# This is the default session manager used by RiveScript to store and retrieve
+# user variables. This session handler just keeps the variables in RAM; if you
+# want to provide your own session handler (e.g. to use a database), you can
+# program your own handler and pass it into the RiveScript constructor:
+#
+# ```javascript
+# var bot = new RiveScript({
+#     sessionHandler: new MySessionHandler()
+# })
+# ```
+#
+# Your custom session handler should be a JavaScript object (class) that
+# implements the following functions:
+#
+# * void set (string username, object vars): For setting user variables. The
+#   `vars` object is a key/value dictionary mapping user variable names (key)
+#   to their values. The values will usually be strings, but can be other types
+#   for some internal data structures (e.g. input/reply histories as arrays).
+# * string get (string username, [string key]): For retrieving a user variable.
+#   Return the string `"undefined"` if the variable doesn't exist. If the `key`
+#   parameter is not provided, this should instead return the full object of
+#   key/value pairs for the user.
+# * object getAll(): Retrieve all user variables for all users. This should
+#   return an object where the top-level key is the username, and the values
+#   are objects of key/value pairs of that user's variables.
+# * void reset (string username): This should delete all variables about the
+#   given username.
+# * void resetAll(): This should delete all variables about all users.
+# * void freeze (string username): Make a snapshot of a user's variables, which
+#   can be later restored using `thaw()`.
+# * void thaw (string username[, string action]): Restore a user's variables
+#   from the frozen snapshot. This should replace *all* their variables with the
+#   set that was frozen. The valid options for `action` are:
+#   * `thaw`: Restore the variables and delete the frozen copy (default).
+#   * `discard`: Don't restore the variables, just delete the frozen copy.
+#   * `keep`: After restoring the user's variables, keep the frozen copy around
+#     anyway (e.g. so future calls to `thaw()` will keep restoring the same
+#     set of variables).
+#
+# All class methods are optional, and RiveScript won't attempt to call them if
+# they haven't been implemented.
+##
+
+class SessionHandler
+  constructor: (warn) ->
+    # In-memory user variable store.
+    @_store  = {}
+    @_freeze = {}
+    @warn    = warn
+
+  set: (username, vars) ->
+    # Initialize the user?
+    if not @_store[username]
+      @_store[username] = {topic: "random"}
+
+    for key of vars
+      continue unless vars.hasOwnProperty key
+      if vars[key] is undefined
+        delete @_store[username][key]
+      else
+        @_store[username][key] = vars[key]
+
+  get: (username, key) ->
+    if key is undefined
+      # Getting all user variables. Return a cloned copy to break refs.
+      return undefined unless @_store[username]
+      return utils.clone @_store[username]
+
+    # No user?
+    if not @_store[username]
+      return "undefined"
+
+    # The var exists?
+    if typeof(@_store[username][key]) isnt "undefined"
+      return @_store[username][key]
+    else
+      return "undefined"
+
+  getAll: ->
+    # All the users! Return a cloned object to break refs.
+    return utils.clone(@_store)
+
+  reset: (username) ->
+    if @_store[username]
+      delete @_store[username]
+
+  resetAll: ->
+    @_store = {}
+
+  freeze: (username) ->
+    if @_store[username]?
+      @_freeze[username] = utils.clone(@_store[username])
+    else
+      @warn "Can't freeze vars for user #{user}: not found!"
+
+  thaw: (username, action="thaw") ->
+    if typeof(action) isnt "string"
+      action = "thaw"
+
+    # Frozen?
+    if not @_freeze[username]?
+      @warn "Can't thaw user vars: #{username} wasn't frozen!"
+      return
+
+    # What are we doing?
+    if action is "thaw"
+      @reset(username)
+      @_store[username] = utils.clone(@_freeze[username])
+      delete @_freeze[username]
+    else if action is "discard"
+      delete @_freeze[username]
+    else if action is "keep"
+      @reset(username)
+      @_store[username] = utils.clone(@_freeze[username])
+    else
+      @warn "Unsupported thaw action!"
+
+module.exports = SessionHandler

--- a/test/test-sessions.coffee
+++ b/test/test-sessions.coffee
@@ -1,0 +1,63 @@
+TestCase = require("./test-base")
+
+################################################################################
+# Session Handler Tests
+################################################################################
+
+exports.test_null_session = (test) ->
+  # With a null session handler (implements no functions), user variables
+  # can't be persisted.
+  bot = new TestCase(test, """
+    + my name is *
+    - <set name=<formal>>Nice to meet you, <get name>.
+
+    + who am i
+    - Aren't you <get name>?
+
+    + what did i just say
+    - You just said: <input1>
+
+    + what did you just say
+    - I just said: <reply1>
+
+    + i hate you
+    - How mean!{topic=apology}
+
+    > topic apology
+      + *
+      - Nope, I'm mad at you.
+    < topic
+  """, {sessionHandler: {}})
+  bot.reply("my name is aiden", "Nice to meet you, undefined.")
+  bot.reply("who am I?", "Aren't you undefined?")
+  bot.reply("What did I just say?", "You just said: undefined")
+  bot.reply("What did you just say?", "I just said: undefined")
+  bot.reply("I hate you", "How mean!")
+  bot.reply("My name is Aiden", "Nice to meet you, undefined.")
+  test.done()
+
+exports.test_freeze_thaw = (test) ->
+  bot = new TestCase(test, """
+    + my name is *
+    - <set name=<formal>>Nice to meet you, <get name>.
+
+    + who am i
+    - Aren't you <get name>?
+  """)
+  bot.reply("My name is Aiden", "Nice to meet you, Aiden.")
+  bot.reply("Who am I?", "Aren't you Aiden?")
+
+  bot.rs.freezeUservars("localuser")
+  bot.reply("My name is Bob", "Nice to meet you, Bob.")
+  bot.reply("Who am I?", "Aren't you Bob?")
+
+  bot.rs.thawUservars("localuser")
+  bot.reply("Who am I?", "Aren't you Aiden?")
+  bot.rs.freezeUservars("localuser")
+
+  bot.reply("My name is Bob", "Nice to meet you, Bob.")
+  bot.reply("Who am I?", "Aren't you Bob?")
+  bot.rs.thawUservars("localuser", "discard")
+  bot.reply("Who am I?", "Aren't you Bob?")
+
+  test.done()


### PR DESCRIPTION
This adds a constructor option `sessionHandler` which provides a hook for third party developers to implement their own session stores (e.g. using Redis or something).

The default session handler, from `src/sessions.coffee` implements the in-memory store that RiveScript previously used. All internal code references to user variables from `RiveScript._users` have been modified to go through the public `setUservar()` function and friends. These functions then delegate to the equivalent functions from the session handler. The core RiveScript library provides no other session handlers, but some may be added as examples in the `eg/` directory in the future.

Session handlers aren't required to implement all functions (the unit test tries setting a "null" session handler which gives the bot really bad amnesia).

Fixes #135 
