### PR TITLE
Prevent errors if history object is invalid

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -290,16 +290,19 @@ class Brain
 
     # Initialize this user's history.
     if not @master._users[user].__history__
-      @master._users[user].__history__ = {
-        "input": [
-          "undefined", "undefined", "undefined", "undefined", "undefined",
-          "undefined", "undefined", "undefined", "undefined", "undefined"
-        ]
-        "reply": [
-          "undefined", "undefined", "undefined", "undefined", "undefined",
-          "undefined", "undefined", "undefined", "undefined", "undefined"
-        ]
-      }
+      @master._users[user].__history__ = {}
+
+    # Update input &/or reply if given array is missing or empty
+    if not @master._users[user].__history__.input || @master._users[user].__history__.input.length == 0
+      @master._users[user].__history__.input = [
+        "undefined", "undefined", "undefined", "undefined", "undefined",
+        "undefined", "undefined", "undefined", "undefined", "undefined"
+      ]
+    if not @master._users[user].__history__.reply || @master._users[user].__history__.reply.length == 0
+      @master._users[user].__history__.reply = [
+        "undefined", "undefined", "undefined", "undefined", "undefined",
+        "undefined", "undefined", "undefined", "undefined", "undefined"
+      ]
 
     # More topic sanity checking.
     if not @master._topics[topic]
@@ -331,7 +334,7 @@ class Brain
           @say "There's a %Previous in this topic!"
 
           # Do we have history yet?
-          lastReply = @master._users[user].__history__.reply[0]
+          lastReply = @master._users[user].__history__.reply[0] || "undefined"
 
           # Format the bot's last reply the same way as the human's.
           lastReply = @formatMessage(lastReply, true)
@@ -794,8 +797,8 @@ class Brain
       reply = reply.replace(new RegExp("<botstar#{i}>", "ig"), botstars[i])
 
     # <input> and <reply>
-    reply = reply.replace(/<input>/ig, @master._users[user].__history__.input[0])
-    reply = reply.replace(/<reply>/ig, @master._users[user].__history__.reply[0])
+    reply = reply.replace(/<input>/ig, @master._users[user].__history__.input[0] || "undefined")
+    reply = reply.replace(/<reply>/ig, @master._users[user].__history__.reply[0] || "undefined")
     for i in [1..9]
       if reply.indexOf("<input#{i}>") > -1
         reply = reply.replace(new RegExp("<input#{i}>", "ig"),

--- a/test/test-rivescript.coffee
+++ b/test/test-rivescript.coffee
@@ -208,3 +208,22 @@ exports.test_initialmatch = (test) ->
   bot.uservar("__initialmatch__", "@thanks{weight=2}")
 
   test.done()
+
+
+exports.test_valid_history = (test) ->
+  bot = new TestCase(test, """
+    + hello
+    - Hi!
+
+    + bye
+    - Goodbye!
+  """)
+
+  bot.reply("Hello", "Hi!")
+
+  # Intentionally set a bad history.
+  bot.rs.setUservar(bot.username, "__history__", {"input": ["Hello"]})
+
+  bot.reply("Bye!", "Goodbye!")
+
+  test.done()


### PR DESCRIPTION
In the case of `__history__` being invalidly set (through settings via `setUservar()`), ensure that `input` and `reply` arrays are set if they do not exist, and that a fallback undefined string is given when requesting `__history__.input[0]` and `__history__.reply[0]` when creating `<input>` and `<reply>` tags.

Example situation:
```
// Set an invalid history
rs.setUservar(userId, "__history__", {"input": ["Hi"], "reply": []});

// Generate response
rs.reply(userId, "Bye");
```

Error generated:
`TypeError: Cannot read property '0' of undefined at Brain.processTags (./node_modules/rivescript/lib/brain.js:663:82)`

A passing test is also provided.