### PR TITLE
Case insensitive regexp for intermediate call tags

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -93,8 +93,8 @@ class Brain
   # and it returns a promise, otherwise a string is returned
   ##
   processCallTags: (reply, scope, async) ->
-    reply = reply.replace(/\{__call__\}/g, "<call>")
-    reply = reply.replace(/\{\/__call__\}/g, "</call>")
+    reply = reply.replace(/\{__call__\}/ig, "<call>")
+    reply = reply.replace(/\{\/__call__\}/ig, "</call>")
     callRe = /<call>([\s\S]+?)<\/call>/ig
     argsRe = /{__call_arg__}([^{]*){\/__call_arg__}/ig
 

--- a/test/test-objects.coffee
+++ b/test/test-objects.coffee
@@ -84,6 +84,42 @@ exports.test_get_variable = (test) ->
   bot.reply("show me var", "test")
   test.done()
 
+exports.test_uppercase_call = (test) ->
+  bot = new TestCase(test, """
+    > begin
+        + request
+        * <bot mood> == happy => {sentence}{ok}{/sentence}
+        * <bot mood> == angry => {uppercase}{ok}{/uppercase}
+        * <bot mood> == sad   => {lowercase}{ok}{/lowercase}
+        - {ok}
+    < begin
+
+    > object test javascript
+        return "The object result.";
+    < object
+
+    // Not much we can do about this part right now... when uppercasing the
+    // whole reply the name of the macro is also uppercased. *shrug*
+    > object TEST javascript
+        return "The object result.";
+    < object
+
+    + *
+    - Hello there. <call>test <star></call>
+  """)
+  bot.reply("hello", "Hello there. The object result.")
+
+  bot.rs.setVariable("mood", "happy")
+  bot.reply("hello", "Hello there. The object result.")
+
+  bot.rs.setVariable("mood", "angry")
+  bot.reply("hello", "HELLO THERE. The object result.")
+
+  bot.rs.setVariable("mood", "sad")
+  bot.reply("hello", "hello there. The object result.")
+
+  test.done()
+
 exports.test_objects_in_conditions = (test) ->
   bot = new TestCase(test, """
     // Normal synchronous object that returns an immediate response.


### PR DESCRIPTION
This makes the regexp to substitute the intermediary "`{__call__}`" tags case-insensitively, to fix #178.

Using an object macro inside a text manipulation tag like `{uppercase}` in a BEGIN block still has more caveats (e.g.: the `{uppercase}` will uppercase the *name* of the object macro, and possibly give you an "[ERR: object not found]" error... but there's only so much I can do about that. Authors can work around it by defining their object macro under multiple names, like when using `setSubroutine`.