### PR TITLE
Force case for topics, and better inheritance error

### DIFF
--- a/src/inheritance.coffee
+++ b/src/inheritance.coffee
@@ -41,7 +41,7 @@ getTopicTriggers = (rs, topic, thats, depth, inheritance, inherited) ->
 
   # Break if we're in too deep.
   if depth > rs._depth
-    rs.warn "Deep recursion while scanning topic inheritance!"
+    rs.warn "Deep recursion while scanning topic inheritance (gave up in topic #{topic})!"
     return []
 
   # Keep in mind here that there is a difference between 'includes' and

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -348,6 +348,10 @@ class Parser
                 type = "topic"
                 name = "__begin__"
 
+              # Force case on topics.
+              if @master._forceCase is true
+                name = name.toLowerCase()
+
               # Starting a new topic.
               @say "Set topic to #{name}"
               curTrig = null
@@ -636,9 +640,11 @@ class Parser
       if parts[0] is "begin" and parts.length > 1
         return "The 'begin' label takes no additional arguments"
       else if parts[0] is "topic"
-        if line.match(/[^a-z0-9_\-\s]/)
+        if not @master._forceCase and line.match(/[^a-z0-9_\-\s]/)
           return "Topics should be lowercased and contain only letters
                   and numbers"
+        else if line.match(/[^A-Za-z0-9_\-\s]/)
+          return "Topics should contain only letters and numbers in forceCase mode"
       else if parts[0] is "object"
         if line.match(/[^A-Za-z0-9\_\-\s]/)
           return "Objects can only contain numbers and letters"

--- a/src/rivescript.coffee
+++ b/src/rivescript.coffee
@@ -724,6 +724,9 @@ class RiveScript
     if value is undefined
       delete @_users[user][name]
     else
+      # Topic? And are we forcing case?
+      if name is "topic" and @_forceCase
+        value = value.toLowerCase()
       @_users[user][name] = value
 
   ##
@@ -739,6 +742,11 @@ class RiveScript
 
     for key of data
       continue unless data.hasOwnProperty key
+
+      # Topic? And are we forcing case?
+      if key is "topic" and @_forceCase
+        data[key] = data[key].toLowerCase()
+
       if data[key] is undefined
         delete @_users[user][key]
       else

--- a/test/test-options.coffee
+++ b/test/test-options.coffee
@@ -159,11 +159,23 @@ exports.test_force_case = (test) ->
     // Note the capital "I", this would raise a parse error normally.
     + I am # years old
     - <set age=<star>>A lot of people are <get age>.
+
+    + enter topic
+    - Enter topic via topic tag.{topic=CapsTopic}
+
+    > topic CapsTopic
+        + *
+        - The topic worked!{topic=random}
+    < topic
   """, { forceCase: true })
 
   bot.reply("hello bot", "Hello human!")
   bot.reply("i am 5 years old", "A lot of people are 5.")
   bot.reply("I am 6 years old", "A lot of people are 6.")
+  bot.rs.setUservar("localuser", "topic", "CapsTopic")
+  bot.reply("hello", "The topic worked!")
+  bot.reply("enter topic", "Enter topic via topic tag.")
+  bot.reply("hello", "The topic worked!")
   test.done()
 
 exports.test_no_force_case = (test) ->


### PR DESCRIPTION
This change allows the `forceCase` option to work on topics, too: both on the `>topic` declaration line and on the `{topic=}` tag, for consistency/sanity. That fixes #158.

This also updates the "deep recursion while scanning topic inheritance" error to include the current topic it was looking at when it gave up the search, to fix #167.