### PR TITLE
Fix sorting algorithm for %Previous

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -342,7 +342,7 @@ class Brain
 
           # See if it's a match
           for trig in @master._sorted.thats[top]
-            pattern = trig[0]
+            pattern = trig[1].previous
             botside = @triggerRegexp(user, pattern)
             @say "Try to match lastReply (#{lastReply}) to #{botside}"
 

--- a/src/inheritance.coffee
+++ b/src/inheritance.coffee
@@ -97,7 +97,8 @@ getTopicTriggers = (rs, topic, thats, depth, inheritance, inherited) ->
         continue unless rs._thats[topic].hasOwnProperty curTrig
         for previous of rs._thats[topic][curTrig]
           continue unless rs._thats[topic][curTrig].hasOwnProperty previous
-          inThisTopic.push [previous, rs._thats[topic][curTrig][previous]]
+          pointer = rs._thats[topic][curTrig][previous]
+          inThisTopic.push [pointer.trigger, pointer]
 
   # Does this topic include others?
   if Object.keys(rs._includes[topic]).length > 0

--- a/test/test-replies.coffee
+++ b/test/test-replies.coffee
@@ -21,6 +21,18 @@ exports.test_previous = (test) ->
     % * who
     - Haha! <sentence>!
 
+    + ask me a question
+    - How many arms do I have?
+
+    + [*] # [*]
+    % how many arms do i have
+    * <star> == 2 => Yes!
+    - No!
+
+    + *
+    % how many arms do i have
+    - That isn't a number.
+
     + *
     - I don't know.
   """)
@@ -28,6 +40,12 @@ exports.test_previous = (test) ->
   bot.reply("Canoe", "Canoe who?")
   bot.reply("Canoe help me with my homework?", "Haha! Canoe help me with my homework!")
   bot.reply("hello", "I don't know.")
+  bot.reply("Ask me a question", "How many arms do I have?")
+  bot.reply("1", "No!")
+  bot.reply("Ask me a question", "How many arms do I have?")
+  bot.reply("2", "Yes!")
+  bot.reply("Ask me a question", "How many arms do I have?")
+  bot.reply("lol", "That isn't a number.")
   test.done()
 
 exports.test_random = (test) ->


### PR DESCRIPTION
This implements the fix to the `%Previous` sorting algorithm identified in [rivescript-python#60](https://github.com/aichaos/rivescript-python/pull/60).