### PR TITLE
[Improvement] Allow forcefully skipping the begin block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "description": "RiveScript is a scripting language for chatterbots, making it easy to write trigger/response pairs for building up a bot's intelligence.",
   "keywords": [
     "bot",

--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -37,7 +37,7 @@ class Brain
   #
   # Fetch a reply for the user.
   ##
-  reply: (user, msg, scope, async) ->
+  reply: (user, msg, scope, async, skipBegin) ->
     @say "Asked to reply to [#{user}] #{msg}"
 
     # Store the current user's ID.
@@ -52,7 +52,7 @@ class Brain
       @master._users[user].__initialmatch__ = undefined
 
     # If the BEGIN block exists, consult it first.
-    if @master._topics.__begin__
+    if not skipBegin and @master._topics.__begin__
       begin = @_getReply(user, "request", "begin", 0, scope)
 
       # OK to continue?

--- a/src/rivescript.coffee
+++ b/src/rivescript.coffee
@@ -911,7 +911,7 @@ class RiveScript
   ##############################################################################
 
   ##
-  # string reply (string username, string message[, scope])
+  # string reply (string username, string message[, scope, skipBegin])
   #
   # Fetch a reply from the RiveScript brain. The message doesn't require any
   # special pre-processing to be done to it, i.e. it's allowed to contain
@@ -927,9 +927,14 @@ class RiveScript
   # or attributes that your code has access to, from the location that `reply()`
   # was called. For an example of this, refer to the `eg/scope` directory in
   # the source distribution of RiveScript-JS.
+  #
+  # The option `skipBegin` parameter can be used to skip any begin blocks.
+  # This is useful for when calling reply from within a macro (when begin
+  # has already been processed) or when executing a system call where the
+  # implementor purposefully wishes to avoid the begin block.
   ##
-  reply: (user, msg, scope) ->
-    return @brain.reply(user, msg, scope)
+  reply: (user, msg, scope, skipBegin) ->
+    return @brain.reply(user, msg, scope, false, skipBegin)
 
   ##
   # Promise replyAsync (string username, string message [[, scope], callback])

--- a/test/test-begin.coffee
+++ b/test/test-begin.coffee
@@ -60,3 +60,19 @@ exports.test_conditional_begin_block = (test) ->
   bot.uservar("name", "Bob")
   bot.reply("Hello Bot", "Bob: Hello human.")
   test.done()
+
+exports.test_skip_begin_block = (test) ->
+  bot = new TestCase(test, """
+    > begin
+        + request
+        - Nope.
+    < begin
+
+    + hello bot
+    - Hello human.
+  """)
+
+  console.log(bot.rs.username)
+  reply = bot.rs.reply(bot.username, "Hello bot.", null, true)
+  test.equal(reply, "Hello human.");
+  test.done()


### PR DESCRIPTION
We've run into a few situations where we want to deliberately skip the begin block: 

1. Executing a trigger initiated by the system (instead of a user) in order to accomplish things like send out a push notification. 
1. Within macros, if you execute rs.reply begin prefixes get executed twice, which can be undesirable. 

Hoping this is relevant to more people!