### PR TITLE
Allow synchronous call tags to work inside redirects

### DIFF
--- a/src/brain.coffee
+++ b/src/brain.coffee
@@ -96,7 +96,7 @@ class Brain
     reply = reply.replace(/«__call__»/ig, "<call>")
     reply = reply.replace(/«\/__call__»/ig, "</call>")
     callRe = /<call>([\s\S]+?)<\/call>/ig
-    argsRe = /«__call_arg__»([\s\S]*?)«\/__call_arg__»/mig
+    argsRe = /«__call_arg__»([\s\S]*?)«\/__call_arg__»/ig
 
     giveup = 0
     matches = {}

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -663,9 +663,9 @@ class Parser
         if line.match(/[A-Z\\.]/)
           return "Triggers can't contain uppercase letters, backslashes or
                   dots in UTF-8 mode"
-      else if line.match(/[^a-z0-9(|)\[\]*_#@{}<>=\s]/)
+      else if line.match(/[^a-z0-9(|)\[\]*_#@{}<>=\/\s]/)
         return "Triggers may only contain lowercase letters, numbers, and
-                these symbols: ( | ) [ ] * _ # { } < > ="
+                these symbols: ( | ) [ ] * _ # { } < > = /"
       else if line.match(/\(\||\|\)/)
         return "Piped alternations can't begin or end with a |"
       else if line.match(/\([^\)].+\|\|.+\)/)

--- a/test/test-objects.coffee
+++ b/test/test-objects.coffee
@@ -176,6 +176,27 @@ exports.test_objects_in_conditions = (test) ->
     )
   )
 
+exports.test_objects_in_redirects = (test) ->
+  bot = new TestCase(test, """
+    > object echo javascript
+      var message = args.join(" ");
+      return message;
+    < object
+
+    + hello bot
+    - Hello human.
+
+    + redirect to *
+    @ <call>echo <star></call>
+
+    + inline to *
+    - "<sentence>": {@ <call>echo <star></call>}
+  """)
+  bot.reply("hello bot", "Hello human.")
+  bot.reply("Redirect to Hello Bot", "Hello human.")
+  bot.reply("Inline to hello bot", '"Hello bot": Hello human.')
+  test.done()
+
 exports.test_line_breaks_in_call = (test) ->
   bot = new TestCase(test, """
     > object macro javascript


### PR DESCRIPTION
This change makes it possible to include **synchronous** object macro calls inside of redirects (both the command and inline form).

This fixes #201.

Example from the unit test:

```
> object echo javascript
  var message = args.join(" ");
  return message;
< object

+ hello bot
- Hello human.

+ redirect to *
@ <call>echo <star></call>

+ inline to *
- "<sentence>": {@ <call>echo <star></call>}
```

This is similar to the bug fix in #111 when object macros were fixed for conditional commands. It only supports **synchronous** macros (ones which return a string reply, *not* a promise) for the same reason.

In order to avoid regular expression problems with the `{@...}` syntax's curly brackets conflicting with those from the mangled `{__call_arg__}` types of tags, I changed the delimiter of the mangled call tags to use the 'LEFT-POINTING DOUBLE ANGLE QUOTATION MARK' (U+00AB) and 'RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK' (U+00BB)' symbols: `«` and `»`. I chose these symbols so that if the call tag fails to parse properly (as it did in the original bug), the resulting text contains printable symbols. `«` and `»` are not used by anything else in RiveScript.