### PR TITLE
Add ?Keyword command to work around Unicode keyword bug

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -169,6 +169,24 @@ class Parser
       if line.indexOf(" //") > -1
         line = utils.strip(line.split(" //")[0])
 
+      # Allow the ?Keyword command to work around UTF-8 bugs for users who
+      # wanted to use `+ [*] keyword [*]` with Unicode symbols that don't match
+      # properly with the usual "optional wildcard" syntax.
+      if cmd is "?"
+        # The ?Keyword command is really an alias to +Trigger with some workarounds
+        # to make it match the keyword _anywhere_, in every variation so it works
+        # with Unicode strings.
+        variants = [
+            line,
+            "[*]#{line}[*]",
+            "*#{line}*",
+            "[*]#{line}*",
+            "*#{line}[*]",
+        ]
+        cmd = "+"
+        line = "(" + variants.join("|") + ")"
+        @say "Rewrote ?Keyword as +Trigger: #{line}"
+
       # In the event of a +Trigger, if we are force-lowercasing it, then do so
       # now before the syntax check.
       if @master._forceCase is true and cmd is "+"

--- a/test/test-unicode.coffee
+++ b/test/test-unicode.coffee
@@ -74,6 +74,35 @@ exports.test_wildcards = (test) ->
   bot.reply("I am 5 years old", "A lot of people are 5 years old.")
   test.done()
 
+# The ?Keyword works around `+ [*] keyword [*]` syntax not working with Unicode.
+exports.test_unicode_keyword = (test) ->
+  bot = new TestCase(test, """
+    ? 你好
+    - Matched 你好 keyword.
+
+    ? пиво
+    - Matched пиво keyword.
+
+    ? some ascii
+    - Matched some ascii keyword.
+  """, {utf8: true})
+
+  bot.reply("你好", "Matched 你好 keyword.")
+  bot.reply("a 你好 b", "Matched 你好 keyword.")
+  bot.reply("你好你好你好", "Matched 你好 keyword.")
+
+  bot.reply("пиво", "Matched пиво keyword.")
+  bot.reply("x пиво y", "Matched пиво keyword.")
+  bot.reply("xпивоy", "Matched пиво keyword.")
+  bot.reply("пивопивопиво", "Matched пиво keyword.")
+
+  bot.reply("some ascii", "Matched some ascii keyword.")
+  bot.reply("want some ascii?", "Matched some ascii keyword.")
+  bot.reply("some ascii is ok", "Matched some ascii keyword.")
+  bot.reply("send some ascii to me", "Matched some ascii keyword.")
+
+  test.done()
+
 exports.test_punctuation = (test) ->
   bot = new TestCase(test, """
     + hello bot


### PR DESCRIPTION
This feature alleviates a huge pain point that a lot of users have experienced with Unicode keyword triggers.

* Fixes #147 
* Fixes #253 
* Fixes #254 

## The Bug

Users wanted to be able to write things like this in their RiveScript code:

```
// (this means "hello" in Chinese)
+ [*] 你好 [*]
- 你好!
```

The intention is that the word `你好` appearing _anywhere_ in a message should be able to match that trigger, as it does when using standard ASCII characters. However, the regexps that make "optional wildcards" like `[*]` work have problems matching against Unicode characters outside the ASCII range.

## The Feature

This adds a new `?Keyword` command to complement the `+Trigger` as a workaround for this very common use case:

```
? 你好
- 你好!
```

Under the hood, the `?Keyword` is re-written into a `+Trigger` which includes the keyword text in _every_ variation of wildcard, optional wildcard, and verbatim text. This makes sure that the keyword matches as expected in all messages that contain it, in a way that works with Unicode.

The JavaScript version gets this feature first because it's the most popular edition of RiveScript.

This will be included in the `v1.19.0` release of `rivescript-js`.

## See Also

* [rivescript-wd#6](https://github.com/aichaos/rivescript-wd/issues/6) that became the central hub ticket for this issue.
* [rivescript-python#78](https://github.com/aichaos/rivescript-python/issues/78) had the same problem in Python.
* [rivescript-go#22](https://github.com/aichaos/rivescript-go/issues/22) had the same problem in Go.