### PR TITLE
Remove escaping underscores in Regular Expressions

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -664,7 +664,7 @@ class Parser
         else if line.match(/[^A-Za-z0-9_\-\s]/)
           return "Topics should contain only letters and numbers in forceCase mode"
       else if parts[0] is "object"
-        if line.match(/[^A-Za-z0-9\_\-\s]/)
+        if line.match(/[^A-Za-z0-9_\-\s]/)
           return "Objects can only contain numbers and letters"
     else if cmd is "+" or cmd is "%" or cmd is "@"
       # + Trigger, % Previous, @ Redirect

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -54,7 +54,7 @@ exports.word_count = (trigger, all) ->
   if all
     words = trigger.split /\s+/
   else
-    words = trigger.split /[\s\*\#\_\|]+/
+    words = trigger.split /[\s\*\#_\|]+/
 
   wc = 0
   for word in words


### PR DESCRIPTION
Escaping the underscore in JavaScript Regular Expressions is not necessary. 

This closes #250 