### PR TITLE
v2: Use Promises for loadFile and loadDirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,29 @@ RiveScript API.
 
 * `reply()` now returns a Promise instead of a string, like `replyAsync()`
   did before.
-* **SOON:** `loadFile()` and `loadDirectory()` will also become
-  Promise-based instead of callback-based.
+* `loadFile()` and `loadDirectory()` now are Promise-based instead of
+  callback-based.
+* `replyAsync()` is now deprecated and will be removed soon.
 
 This means your use of `reply()` will need to be updated to use the
 Promise. If you are already using `replyAsync()`, just replace the
 function name with `reply()` and it works the same way.
 
 ```diff
-- var reply = bot.reply(username, message);
-+ bot.reply(username, message).then(function(reply) {
-    console.log("Bot> ", reply);
-+ });
+  var bot = new RiveScript();
+- bot.loadDirectory("./brain", onSuccess, onError);
++ bot.loadDirectory("./brain").then(onReady).catch(onError);
+
+  function onReady() {
+      bot.sortReplies();
+      console.log("Bot is ready!");
+
+-     var reply = bot.reply(username, message);
+-     console.log("Bot>", reply);
++     bot.reply(username, message).then(function(reply) {
++         console.log("Bot> ", reply);
++     });
+  }
 ```
 
 ## DOCUMENTATION
@@ -112,10 +123,10 @@ var bot = new RiveScript();
 
 // Load a directory full of RiveScript documents (.rive files). This is for
 // Node.JS only: it doesn't work on the web!
-bot.loadDirectory("brain", loading_done, loading_error);
+bot.loadDirectory("brain").then(loading_done).catch(loading_error);
 
 // Load an individual file.
-bot.loadFile("brain/testsuite.rive", loading_done, loading_error);
+bot.loadFile("brain/testsuite.rive").then(loading_done).catch(loading_error);
 
 // Load a list of files all at once (the best alternative to loadDirectory
 // for the web!)
@@ -123,27 +134,27 @@ bot.loadFile([
   "brain/begin.rive",
   "brain/admin.rive",
   "brain/clients.rive"
-], loading_done, loading_error);
+]).then(loading_done).catch(loading_error);
 
 // All file loading operations are asynchronous, so you need handlers
 // to catch when they've finished. If you use loadDirectory (or loadFile
 // with multiple file names), the success function is called only when ALL
 // the files have finished loading.
-function loading_done (batch_num) {
-  console.log("Batch #" + batch_num + " has finished loading!");
+function loading_done() {
+  console.log("Bot has finished loading!");
 
   // Now the replies must be sorted!
   bot.sortReplies();
 
   // And now we're free to get a reply from the brain!
   // NOTE: the API has changed in v2.0.0 and returns a Promise now.
-  var reply = bot.reply("local-user", "Hello, bot!").then(function(reply) {
+  bot.reply("local-user", "Hello, bot!").then(function(reply) {
     console.log("The bot says: " + reply);
   });
 }
 
 // It's good to catch errors too!
-function loading_error (error) {
+function loading_error(error, filename, lineno) {
   console.log("Error when loading files: " + error);
 }
 ```

--- a/contrib/coffeescript/test/base.js
+++ b/contrib/coffeescript/test/base.js
@@ -13,17 +13,18 @@ var TestCase = function(test, code, ready, opts) {
 	// Initialize RiveScript.
 	self.rs = new RiveScript(opts);
 	self.rs.setHandler("coffeescript", new CoffeeHandler(self.rs));
-	self.rs.loadFile("test/fixtures/" + code, function() {
+	self.rs.loadFile("test/fixtures/" + code).then(function() {
 		self.rs.sortReplies();
 		ready();
-	}, function(error) {
+	}).catch(function(error) {
 		console.error("Failed to load file: " + error);
 	});
 
 	// Reply assertion.
 	self.reply = function(message, expected) {
-		var reply = self.rs.reply(self.username, message);
-		self.test.equal(reply, expected);
+		self.rs.reply(self.username, message).then(function(reply) {
+			self.test.equal(reply, expected);
+		});
 	};
 }
 

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -2,17 +2,11 @@
 
 Create a Brain object which handles the actual process of fetching a reply.
 
-## string reply (string user, string msg[, scope])
+# async reply (string user, string msg[, scope])
 
-Fetch a reply for the user.
+Fetch a reply for the user. This returns a Promise that may be awaited on.
 
-## string|Promise processCallTags (string reply, object scope, bool async)
-
-Process <call> tags in the preprocessed reply string.
-If `async` is true, processCallTags can handle asynchronous subroutines
-and it returns a promise, otherwise a string is returned
-
-## string _getReply (string user, string msg, string context, int step, scope)
+# async _getReply (string user, string msg, string context, int step, scope)
 
 The internal reply method. DO NOT CALL THIS DIRECTLY.
 
@@ -32,9 +26,6 @@ Prepares a trigger for the regular expression engine.
 ## string processTags (string user, string msg, string reply, string[] stars, string[] botstars, int step, scope)
 
 Process tags in a reply element.
-
-All the tags get processed here except for `<call>` tags which have
-a separate subroutine (refer to `processCallTags` for more info)
 
 ## string substitute (string msg, string type)
 

--- a/docs/html/brain.html
+++ b/docs/html/brain.html
@@ -8,13 +8,9 @@
 
 <h1>Brain (RiveScript master)</h1>
 <p>Create a Brain object which handles the actual process of fetching a reply.</p>
-<h2>string reply (string user, string msg[, scope])</h2>
-<p>Fetch a reply for the user.</p>
-<h2>string|Promise processCallTags (string reply, object scope, bool async)</h2>
-<p>Process &lt;call&gt; tags in the preprocessed reply string.
-If <code>async</code> is true, processCallTags can handle asynchronous subroutines
-and it returns a promise, otherwise a string is returned</p>
-<h2>string _getReply (string user, string msg, string context, int step, scope)</h2>
+<h1>async reply (string user, string msg[, scope])</h1>
+<p>Fetch a reply for the user. This returns a Promise that may be awaited on.</p>
+<h1>async _getReply (string user, string msg, string context, int step, scope)</h1>
 <p>The internal reply method. DO NOT CALL THIS DIRECTLY.</p>
 <ul>
 <li>user, msg and scope are the same as reply()</li>
@@ -28,8 +24,6 @@ and it returns a promise, otherwise a string is returned</p>
 <p>Prepares a trigger for the regular expression engine.</p>
 <h2>string processTags (string user, string msg, string reply, string[] stars, string[] botstars, int step, scope)</h2>
 <p>Process tags in a reply element.</p>
-<p>All the tags get processed here except for <code>&lt;call&gt;</code> tags which have
-a separate subroutine (refer to <code>processCallTags</code> for more info)</p>
 <h2>string substitute (string msg, string type)</h2>
 <p>Run substitutions against a message. <code>type</code> is either "sub" or "person" for
 the type of substitution to run.</p>

--- a/docs/html/lang.coffee.html
+++ b/docs/html/lang.coffee.html
@@ -9,8 +9,8 @@
 <h1>CoffeeObjectHandler (RiveScript master)</h1>
 <p>CoffeeScript Language Support for RiveScript Macros. This language is not
 enabled by default; to enable CoffeeScript object macros:</p>
-<div class="codehilite"><pre><span></span>   <span class="nv">CoffeeObjectHandler = </span><span class="nx">require</span> <span class="s">&quot;rivescript/lang/coffee&quot;</span>
-   <span class="nx">bot</span><span class="p">.</span><span class="nx">setHandler</span> <span class="s">&quot;coffee&quot;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">CoffeeObjectHandler</span>
+<div class="codehilite"><pre><span></span><span class="nv">CoffeeObjectHandler = </span><span class="nx">require</span> <span class="s">&quot;rivescript/lang/coffee&quot;</span>
+<span class="nx">bot</span><span class="p">.</span><span class="nx">setHandler</span> <span class="s">&quot;coffee&quot;</span><span class="p">,</span> <span class="k">new</span> <span class="nx">CoffeeObjectHandler</span>
 </pre></div>
 
 

--- a/docs/html/lang.javascript.html
+++ b/docs/html/lang.javascript.html
@@ -10,7 +10,7 @@
 <p>JavaScript Language Support for RiveScript Macros. This support is enabled by
 default in RiveScript.js; if you don't want it, override the <code>javascript</code>
 language handler to null, like so:</p>
-<div class="codehilite"><pre><span></span>   <span class="nx">bot</span><span class="p">.</span><span class="nx">setHandler</span><span class="p">(</span><span class="s2">&quot;javascript&quot;</span><span class="p">,</span> <span class="kc">null</span><span class="p">);</span>
+<div class="codehilite"><pre><span></span><span class="nx">bot</span><span class="p">.</span><span class="nx">setHandler</span><span class="p">(</span><span class="s2">&quot;javascript&quot;</span><span class="p">,</span> <span class="kc">null</span><span class="p">);</span>
 </pre></div>
 
 

--- a/docs/html/parser.html
+++ b/docs/html/parser.html
@@ -8,7 +8,7 @@
 
 <h1>Parser (RiveScript master)</h1>
 <p>Create a parser object to handle parsing RiveScript code.</p>
-<h2>data parse (string filename, string code[, func onError])</h2>
+<h2>object parse (string filename, string code[, func onError])</h2>
 <p>Read and parse a RiveScript document. Returns a data structure that
 represents all of the useful contents of the document, in this format:</p>
 <div class="codehilite"><pre><span></span><span class="p">{</span>
@@ -46,6 +46,7 @@ represents all of the useful contents of the document, in this format:</p>
 </pre></div>
 
 
+<p>onError function receives: <code>(err string[, filename str, line_no int])</code></p>
 <h2>string stringify (data deparsed)</h2>
 <p>Translate deparsed data into the source code of a RiveScript document.
 See the <code>stringify()</code> method on the parent RiveScript class; this is its

--- a/docs/html/rivescript.html
+++ b/docs/html/rivescript.html
@@ -26,7 +26,7 @@ following keys:</p>
 * bool forceCase: Force-lowercase triggers (default false, see below)
 * func onDebug:   Set a custom handler to catch debug log messages (default null)
 * obj  errors:    Customize certain error messages (see below)
-* str  concat:    Globally override the concatenation mode when parsing
+* str  concat:    Globally replace the default concatenation mode when parsing
                   RiveScript source files (default `null`. be careful when
                   setting this option if using somebody else&#39;s RiveScript
                   personality; see below)
@@ -82,70 +82,59 @@ give it to somebody else to use in their bot.</p>
 argument to the constructor to override certain internal error messages:</p>
 <ul>
 <li><code>replyNotMatched</code>: The message returned when the user's message does not
-  match any triggers in your RiveScript code.</li>
+match any triggers in your RiveScript code.</li>
 </ul>
 <p>The default is "ERR: No Reply Matched"</p>
 <p><strong>Note:</strong> the recommended way to handle this case is to provide a trigger of
-  simply <code>*</code>, which serves as the catch-all trigger and is the default one
-  that will match if nothing else matches the user's message. Example:</p>
-<p><code>+ *
-  - I don't know what to say to that!</code>
-<em> <code>replyNotFound</code>: This message is returned when the user </em>did* in fact match
-  a trigger, but no response was found for the user. For example, if a trigger
-  only checks a set of conditions that are all false and provides no "normal"
-  reply, this error message is given to the user instead.</p>
+simply <code>*</code>, which serves as the catch-all trigger and is the default one
+that will match if nothing else matches the user's message. Example:</p>
+<div class="codehilite"><pre><span></span>+ *
+- I don&#39;t know what to say to that!
+</pre></div>
+
+
+<ul>
+<li><code>replyNotFound</code>: This message is returned when the user <em>did</em> in fact match
+a trigger, but no response was found for the user. For example, if a trigger
+only checks a set of conditions that are all false and provides no "normal"
+reply, this error message is given to the user instead.</li>
+</ul>
 <p>The default is "ERR: No Reply Found"</p>
 <p><strong>Note:</strong> the recommended way to handle this case is to provide at least one
-  normal reply (with the <code>-</code> command) to every trigger to cover the cases
-  where none of the conditions are true. Example:</p>
-<p><code>+ hello
-  * &lt;get name&gt; != undefined =&gt; Hello there, &lt;get name&gt;.
-  - Hi there.</code>
-* <code>objectNotFound</code>: This message is inserted into the bot's reply in-line when
-  it attempts to call an object macro which does not exist (for example, its
-  name was invalid or it was written in a programming language that the bot
-  couldn't parse, or that it had compile errors).</p>
+normal reply (with the <code>-</code> command) to every trigger to cover the cases
+where none of the conditions are true. Example:</p>
+<div class="codehilite"><pre><span></span>+ hello
+* &lt;get name&gt; != undefined =&gt; Hello there, &lt;get name&gt;.
+- Hi there.
+</pre></div>
+
+
+<ul>
+<li><code>objectNotFound</code>: This message is inserted into the bot's reply in-line when
+it attempts to call an object macro which does not exist (for example, its
+name was invalid or it was written in a programming language that the bot
+couldn't parse, or that it had compile errors).</li>
+</ul>
 <p>The default is "[ERR: Object Not Found]"
 * <code>deepRecursion</code>: This message is inserted when the bot encounters a deep
-  recursion situation, for example when a reply redirects to a trigger which
-  redirects back to the first trigger, creating an infinite loop.</p>
+recursion situation, for example when a reply redirects to a trigger which
+redirects back to the first trigger, creating an infinite loop.</p>
 <p>The default is "ERR: Deep Recursion Detected"</p>
 <p>These custom error messages can be provided during the construction of the
 RiveScript object, or set afterwards on the object's <code>errors</code> property.</p>
 <p>Examples:</p>
 <div class="codehilite"><pre><span></span><span class="kd">var</span> <span class="nx">bot</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">RiveScript</span><span class="p">({</span>
-   <span class="nx">errors</span><span class="o">:</span> <span class="p">{</span>
-       <span class="nx">replyNotFound</span><span class="o">:</span> <span class="s2">&quot;I don&#39;t know how to reply to that.&quot;</span>
-   <span class="p">}</span>
+<span class="nx">errors</span><span class="o">:</span> <span class="p">{</span>
+<span class="nx">replyNotFound</span><span class="o">:</span> <span class="s2">&quot;I don&#39;t know how to reply to that.&quot;</span>
+<span class="p">}</span>
 <span class="p">});</span>
 
 <span class="nx">bot</span><span class="p">.</span><span class="nx">errors</span><span class="p">.</span><span class="nx">objectNotFound</span> <span class="o">=</span> <span class="s2">&quot;Something went terribly wrong.&quot;</span><span class="p">;</span>
 </pre></div>
 
 
-<h1>Constructor and Debug Methods</h1>
 <h2>string version ()</h2>
 <p>Returns the version number of the RiveScript.js library.</p>
-<h2>Promise Promise</h2>
-<p>Alias for <code>RSVP.Promise</code> for use in async object macros.</p>
-<p>This enables you to create a JavaScript object macro that returns a promise
-for asynchronous tasks (e.g. polling a web API or database). Example:</p>
-<div class="codehilite"><pre><span></span><span class="nx">rs</span><span class="p">.</span><span class="nx">setSubroutine</span><span class="p">(</span><span class="s2">&quot;asyncHelper&quot;</span><span class="p">,</span> <span class="kd">function</span> <span class="p">(</span><span class="nx">rs</span><span class="p">,</span> <span class="nx">args</span><span class="p">)</span> <span class="p">{</span>
- <span class="k">return</span> <span class="k">new</span> <span class="nx">rs</span><span class="p">.</span><span class="nb">Promise</span><span class="p">(</span><span class="kd">function</span> <span class="p">(</span><span class="nx">resolve</span><span class="p">,</span> <span class="nx">reject</span><span class="p">)</span> <span class="p">{</span>
-   <span class="nx">resolve</span><span class="p">(</span><span class="mi">42</span><span class="p">);</span>
- <span class="p">});</span>
-<span class="p">});</span>
-</pre></div>
-
-
-<p>If you're using promises in your object macros, you need to get a reply from
-the bot using the <code>replyAsync()</code> method instead of <code>reply()</code>, for example:</p>
-<div class="codehilite"><pre><span></span><span class="nx">rs</span><span class="p">.</span><span class="nx">replyAsync</span><span class="p">(</span><span class="nx">username</span><span class="p">,</span> <span class="nx">message</span><span class="p">,</span> <span class="k">this</span><span class="p">).</span><span class="nx">then</span><span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">reply</span><span class="p">)</span> <span class="p">{</span>
-   <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">&quot;Bot&gt; &quot;</span><span class="p">,</span> <span class="nx">reply</span><span class="p">);</span>
-<span class="p">});</span>
-</pre></div>
-
-
 <h2>private void runtime ()</h2>
 <p>Detect the runtime environment of this module, to determine if we're
 running in a web browser or from node.</p>
@@ -158,34 +147,32 @@ handler if you defined one.</p>
 be given to the user one way or another. If the <code>onDebug</code> handler is
 defined, this is sent there. If <code>console</code> is available, this will be sent
 there. In a worst case scenario, an alert box is shown.</p>
-<h1>Loading and Parsing Methods</h1>
-<h2>int loadFile (string path || array path[, onSuccess[, onError]])</h2>
+<h1>async loadFile(string path || array path)</h1>
 <p>Load a RiveScript document from a file. The path can either be a string that
 contains the path to a single file, or an array of paths to load multiple
-files. <code>onSuccess</code> is a function to be called when the file(s) have been
-successfully loaded. <code>onError</code> is for catching any errors, such as syntax
-errors.</p>
-<p>This loading method is asynchronous. You should define an <code>onSuccess</code>
-handler to be called when the file(s) have been successfully loaded.</p>
-<p>This method returns a "batch number" for this load attempt. The first call
-to this function will have the batch number of 0 and that will go up from
-there. This batch number is passed to your <code>onSuccess</code> handler as its only
-argument, in case you want to correlate it with your call to <code>loadFile()</code>.</p>
-<p><code>onSuccess</code> receives: int batchNumber
-<code>onError</code> receives: string errorMessage[, int batchNumber]</p>
-<h2>void loadDirectory (string path[, func onSuccess[, func onError]])</h2>
+files. The Promise resolves when all of the files have been parsed and
+loaded. The Promise rejects on error.</p>
+<p>This loading method is asynchronous so you must resolve the promise or
+await it before you go on to sort the replies.</p>
+<ul>
+<li>resolves: <code>()</code></li>
+<li>rejects: <code>(string error)</code></li>
+</ul>
+<h1>async loadDirectory (string path)</h1>
 <p>Load RiveScript documents from a directory recursively.</p>
 <p>This function is not supported in a web environment.</p>
 <h2>bool stream (string code[, func onError])</h2>
-<p>Stream in RiveScript code dynamically. <code>code</code> should be the raw RiveScript
-source code as a string (with line breaks after each line).</p>
-<p>This function is synchronous, meaning there is no success handler needed.
-It will return false on parsing error, true otherwise.</p>
-<p><code>onError</code> receives: string errorMessage</p>
-<h2>private bool parse (string name, string code[, func onError])</h2>
+<p>Load RiveScript source code from a string. <code>code</code> should be the raw
+RiveScript source code, with line breaks separating each line.</p>
+<p>This function is synchronous, meaning it does not return a Promise. It
+parses the code immediately and returns. Do not fear: the parser runs
+very quickly.</p>
+<p>Returns <code>true</code> if the code parsed with no error.</p>
+<p>onError function receives: <code>(err string[, filename str, line_no int])</code></p>
+<h2>private bool parse (string name, string code[, func onError(string)])</h2>
 <p>Parse RiveScript code and load it into memory. <code>name</code> is a file name in case
-syntax errors need to be pointed out. <code>code</code> is the source code, and
-<code>onError</code> is a function to call when a syntax error occurs.</p>
+syntax errors need to be pointed out. <code>code</code> is the source code.</p>
+<p>Returns <code>true</code> if the code parsed with no error.</p>
 <h2>void sortReplies()</h2>
 <p>After you have finished loading your RiveScript code, call this method to
 populate the various sort buffers. This is absolutely necessary for reply
@@ -218,7 +205,6 @@ only run from a Node environment.</p>
 <p>This calls the <code>stringify()</code> method and writes the output into the filename
 specified. You can provide your own deparse-compatible data structure,
 or else the current state of the bot's brain is used instead.</p>
-<h1>Public Configuration Methods</h1>
 <h2>void setHandler(string lang, object)</h2>
 <p>Set a custom language handler for RiveScript object macros. See the source
 for the built-in JavaScript handler (src/lang/javascript.coffee) as an
@@ -278,6 +264,10 @@ entire variable state, so that it can be restored later with
 <p>Retrieve the trigger that the user matched initially. This will return
 only the first matched trigger and will not include subsequent redirects.</p>
 <p>This value is reset on each <code>reply()</code> or <code>replyAsync()</code> call.</p>
+<h2>object lastTriggers (string user)</h2>
+<p>Retrieve the triggers that have been matched for the last reply. This
+will contain all matched trigger with every subsequent redirects.</p>
+<p>This value is reset on each <code>reply()</code> or <code>replyAsync()</code> call.</p>
 <h2>object getUserTopicTriggers (string username)</h2>
 <p>Retrieve the triggers in the current topic for the specified user. It can
 be used to create a UI that gives the user options based on trigges, e.g.
@@ -291,13 +281,15 @@ object macro to get the ID of the user who invoked the macro (e.g. to
 get/set user variables for them).</p>
 <p>This will return undefined if called from outside of a reply context
 (the value is unset at the end of the <code>reply()</code> method)</p>
-<h1>Reply Fetching Methods</h1>
-<h2>string reply (string username, string message[, scope])</h2>
+<h2>Promise reply (string username, string message[, scope])</h2>
 <p>Fetch a reply from the RiveScript brain. The message doesn't require any
 special pre-processing to be done to it, i.e. it's allowed to contain
 punctuation and weird symbols. The username is arbitrary and is used to
 uniquely identify the user, in the case that you may have multiple
 distinct users chatting with your bot.</p>
+<p><strong>Changed in version 2.0.0:</strong> this function used to return a string, but
+therefore didn't support async object macros or session managers. This
+function now returns a Promise (obsoleting the <code>replyAsync()</code> function).</p>
 <p>The optional <code>scope</code> parameter will be passed down into any JavaScript
 object macros that the RiveScript code executes. If you pass the special
 variable <code>this</code> as the scope parameter, then <code>this</code> in the context of an
@@ -306,7 +298,22 @@ so for example the object macro will have access to any local functions
 or attributes that your code has access to, from the location that <code>reply()</code>
 was called. For an example of this, refer to the <code>eg/scope</code> directory in
 the source distribution of RiveScript-JS.</p>
+<p>Example:</p>
+<div class="codehilite"><pre><span></span><span class="c1">// Normal usage as a promise</span>
+<span class="nx">bot</span><span class="p">.</span><span class="nx">reply</span><span class="p">(</span><span class="nx">username</span><span class="p">,</span> <span class="nx">message</span><span class="p">,</span> <span class="k">this</span><span class="p">).</span><span class="nx">then</span><span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">reply</span><span class="p">)</span> <span class="p">{</span>
+    <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">&quot;Bot&gt;&quot;</span><span class="p">,</span> <span class="nx">reply</span><span class="p">);</span>
+<span class="p">});</span>
+
+<span class="c1">// Async-Await usage in an async function.</span>
+<span class="nx">async</span> <span class="kd">function</span> <span class="nx">getReply</span><span class="p">(</span><span class="nx">username</span><span class="p">,</span> <span class="nx">message</span><span class="p">)</span> <span class="p">{</span>
+    <span class="kd">var</span> <span class="nx">reply</span> <span class="o">=</span> <span class="nx">await</span> <span class="nx">bot</span><span class="p">.</span><span class="nx">reply</span><span class="p">(</span><span class="nx">username</span><span class="p">,</span> <span class="nx">message</span><span class="p">);</span>
+    <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">&quot;Bot&gt;&quot;</span><span class="p">,</span> <span class="nx">reply</span><span class="p">);</span>
+<span class="p">}</span>
+</pre></div>
+
+
 <h2>Promise replyAsync (string username, string message [[, scope], callback])</h2>
+<p><strong>Obsolete as of v2.0.0</strong> -- use <code>reply()</code> instead in new code.</p>
 <p>Asyncronous version of reply. Use replyAsync if at least one of the subroutines
 used with the <code>&lt;call&gt;</code> tag returns a promise.</p>
 <p>Example: using promises</p>
@@ -325,6 +332,30 @@ used with the <code>&lt;call&gt;</code> tag returns a promise.</p>
   <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
     <span class="nx">console</span><span class="p">.</span><span class="nx">error</span><span class="p">(</span><span class="s2">&quot;Error: &quot;</span><span class="p">,</span> <span class="nx">error</span><span class="p">);</span>
   <span class="p">}</span>
+<span class="p">});</span>
+</pre></div>
+
+
+<h2>Promise Promise</h2>
+<p><strong>DEPRECATED</strong></p>
+<p>Backwards compatible alias to the native JavaScript <code>Promise</code> object.</p>
+<p><code>rs.Promise</code> used to refer to an <code>RSVP.Promise</code> which acted as a polyfill
+for older systems. In new code, return a native Promise directly from your
+object macros.</p>
+<p>This enables you to create a JavaScript object macro that returns a promise
+for asynchronous tasks (e.g. polling a web API or database). Example:</p>
+<div class="codehilite"><pre><span></span><span class="nx">rs</span><span class="p">.</span><span class="nx">setSubroutine</span><span class="p">(</span><span class="s2">&quot;asyncHelper&quot;</span><span class="p">,</span> <span class="kd">function</span> <span class="p">(</span><span class="nx">rs</span><span class="p">,</span> <span class="nx">args</span><span class="p">)</span> <span class="p">{</span>
+ <span class="k">return</span> <span class="k">new</span> <span class="nx">rs</span><span class="p">.</span><span class="nb">Promise</span><span class="p">(</span><span class="kd">function</span> <span class="p">(</span><span class="nx">resolve</span><span class="p">,</span> <span class="nx">reject</span><span class="p">)</span> <span class="p">{</span>
+   <span class="nx">resolve</span><span class="p">(</span><span class="mi">42</span><span class="p">);</span>
+ <span class="p">});</span>
+<span class="p">});</span>
+</pre></div>
+
+
+<p>If you're using promises in your object macros, you need to get a reply from
+the bot using the <code>replyAsync()</code> method instead of <code>reply()</code>, for example:</p>
+<div class="codehilite"><pre><span></span><span class="nx">rs</span><span class="p">.</span><span class="nx">replyAsync</span><span class="p">(</span><span class="nx">username</span><span class="p">,</span> <span class="nx">message</span><span class="p">,</span> <span class="k">this</span><span class="p">).</span><span class="nx">then</span><span class="p">(</span><span class="kd">function</span><span class="p">(</span><span class="nx">reply</span><span class="p">)</span> <span class="p">{</span>
+   <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s2">&quot;Bot&gt; &quot;</span><span class="p">,</span> <span class="nx">reply</span><span class="p">);</span>
 <span class="p">});</span>
 </pre></div>
 

--- a/docs/html/utils.html
+++ b/docs/html/utils.html
@@ -31,10 +31,18 @@ object 'b' are inserted into 'a'.</p>
 - sentence
 - uppercase
 - lowercase</p>
+<h2>[]string parseCallArgs</h2>
+<p>Parse a string and return shell-like arguments as an array. Normally this
+means each word in the string becomes an item in the result, but quoted
+sections of the input will come back as a single item.</p>
+<p>Example:</p>
+<div class="codehilite"><pre><span></span><span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span> <span class="nx">parseCallArgs</span><span class="p">(</span><span class="s1">&#39;please google &quot;writing chat bot&quot;&#39;</span><span class="p">));</span>
+<span class="c1">// [&quot;please&quot;, &quot;google&quot;, &quot;writing chat bot&quot;]</span>
+</pre></div>
+
+
 <h2>object clone (object)</h2>
 <p>Clone an object.</p>
-<h2>boolean isAPromise (object)</h2>
-<p>Determines if obj looks like a promise</p>
 <h2>int nIndexOf (string, string match, int index)</h2>
 <p>Finds a match in a string at a given index</p>
 <p>Usage:

--- a/docs/lang.coffee.md
+++ b/docs/lang.coffee.md
@@ -4,8 +4,8 @@ CoffeeScript Language Support for RiveScript Macros. This language is not
 enabled by default; to enable CoffeeScript object macros:
 
 ```coffeescript
-   CoffeeObjectHandler = require "rivescript/lang/coffee"
-   bot.setHandler "coffee", new CoffeeObjectHandler
+CoffeeObjectHandler = require "rivescript/lang/coffee"
+bot.setHandler "coffee", new CoffeeObjectHandler
 ```
 
 ## void load (string name, string[] code)

--- a/docs/lang.javascript.md
+++ b/docs/lang.javascript.md
@@ -5,7 +5,7 @@ default in RiveScript.js; if you don't want it, override the `javascript`
 language handler to null, like so:
 
 ```javascript
-   bot.setHandler("javascript", null);
+bot.setHandler("javascript", null);
 ```
 
 ## void load (string name, string[]|function code)

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -2,7 +2,7 @@
 
 Create a parser object to handle parsing RiveScript code.
 
-## data parse (string filename, string code[, func onError])
+## object parse (string filename, string code[, func onError])
 
 Read and parse a RiveScript document. Returns a data structure that
 represents all of the useful contents of the document, in this format:
@@ -41,6 +41,8 @@ represents all of the useful contents of the document, in this format:
   ]
 }
 ```
+
+onError function receives: `(err string[, filename str, line_no int])`
 
 ## string stringify (data deparsed)
 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -40,13 +40,22 @@ Formats a string according to one of the following types:
 - uppercase
 - lowercase
 
+## []string parseCallArgs
+
+Parse a string and return shell-like arguments as an array. Normally this
+means each word in the string becomes an item in the result, but quoted
+sections of the input will come back as a single item.
+
+Example:
+
+```javascript
+console.log( parseCallArgs('please google "writing chat bot"'));
+// ["please", "google", "writing chat bot"]
+```
+
 ## object clone (object)
 
 Clone an object.
-
-## boolean isAPromise (object)
-
-Determines if obj looks like a promise
 
 ## int nIndexOf (string, string match, int index)
 

--- a/eg/coffeescript/coffeebot.js
+++ b/eg/coffeescript/coffeebot.js
@@ -2,6 +2,7 @@
 // See the accompanying README.md for details.
 
 // Run this demo: `node coffeebot.js`
+require("babel-polyfill");
 
 var readline = require("readline");
 
@@ -14,47 +15,46 @@ var RSCoffeeScript = require("rivescript-contrib-coffeescript");
 
 // Create a prototypical class for our own chatbot.
 var CoffeeBot = function(onReady) {
-    var self = this;
-    self.rs = new RiveScript();
+	var self = this;
+	self.rs = new RiveScript();
 
-    // Register the CoffeeScript handler.
-    self.rs.setHandler("coffee", new RSCoffeeScript(self.rs));
+	// Register the CoffeeScript handler.
+	self.rs.setHandler("coffee", new RSCoffeeScript(self.rs));
 
-    // Load the replies and process them.
-    self.rs.loadFile("../brain/coffee.rive", function() {
-        self.rs.sortReplies();
-        onReady();
-    });
+	// Load the replies and process them.
+	self.rs.loadFile("../brain/coffee.rive").then(function() {
+		self.rs.sortReplies();
+		onReady();
+	});
 
-    self.getReply = function(username, message) {
-        return self.rs.reply(username, message);
-    };
+	self.getReply = function(username, message) {
+		return self.rs.reply(username, message, self);
+	};
 };
 
 // Create and run the example bot.
 var bot = new CoffeeBot(function() {
-    // Set up a reader for the standard input for chatting with the bot in your
-    // terminal window.
-    var rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
+	// Set up a reader for the standard input for chatting with the bot in your
+	// terminal window.
+	var rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
 
-    rl.setPrompt("> ");
-    rl.prompt();
-    rl.on("line", function(cmd) {
-        // Handle commands.
-        if (cmd === "/quit") {
-            process.exit(0);
-        } else {
-            // Get a reply from the bot.
-            var reply = bot.getReply("soandso", cmd);
-        }
-
-        console.log("Bot>", reply);
-
-        rl.prompt();
-    }).on("close", function() {
-        process.exit(0);
-    });
+	rl.setPrompt("> ");
+	rl.prompt();
+	rl.on("line", function(cmd) {
+		// Handle commands.
+		if (cmd === "/quit") {
+			process.exit(0);
+		} else {
+			// Get a reply from the bot.
+			bot.getReply("soandso", cmd).then(function(reply) {
+				console.log("Bot>", reply);
+				rl.prompt();
+			});
+		}
+	}).on("close", function() {
+		process.exit(0);
+	});
 });

--- a/eg/coffeescript/package-lock.json
+++ b/eg/coffeescript/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "rs-coffee-example",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "rivescript-contrib-coffeescript": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/rivescript-contrib-coffeescript/-/rivescript-contrib-coffeescript-0.0.1.tgz",
+      "integrity": "sha1-V/N2NFRi6IRZ865TQdtMUFd5xfI=",
+      "requires": {
+        "coffee-script": "1.10.0"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.10.0.tgz",
+          "integrity": "sha1-EpOLz5vhlI+gBvkuDEyegXBRCMA="
+        }
+      }
+    }
+  }
+}

--- a/eg/deparse/README.md
+++ b/eg/deparse/README.md
@@ -99,12 +99,12 @@ looks like.
 
   ```javascript
   var bot = new RiveScript();
-  bot.loadFile("example.rive", function() {
+  bot.loadFile("example.rive").then(function() {
     bot.sortReplies();
 
     var deparsed = bot.deparse();
     console.log(JSON.stringify(deparsed, null, 2));
-  }
+  }).catch(console.error);
   ```
 
 * RiveScript Code (`example.rive`)

--- a/eg/json-server/package-lock.json
+++ b/eg/json-server/package-lock.json
@@ -1,0 +1,369 @@
+{
+  "name": "json-server",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+      "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.5.3"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "body-parser": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+      "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
+      "requires": {
+        "bytes": "2.2.0",
+        "content-type": "1.0.4",
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "http-errors": "1.3.1",
+        "iconv-lite": "0.4.13",
+        "on-finished": "2.3.0",
+        "qs": "5.2.0",
+        "raw-body": "2.1.7",
+        "type-is": "1.6.16"
+      }
+    },
+    "bytes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+      "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg="
+    },
+    "content-disposition": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+      "integrity": "sha1-h0dsamfI2qh+Muh2Ft+IO6f7Bxs="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+      "integrity": "sha1-armUiksa4hlSzSWIUwpHItQETXw="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+      "integrity": "sha1-A9MLX2fdbmMtKUXTDWZScxo01dg="
+    },
+    "express": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+      "integrity": "sha1-PAt288d1kMg0VzkGHsC9O6Bn7CQ=",
+      "requires": {
+        "accepts": "1.2.13",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "1.0.4",
+        "cookie": "0.1.5",
+        "cookie-signature": "1.0.6",
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "escape-html": "1.0.3",
+        "etag": "1.7.0",
+        "finalhandler": "0.4.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.0.10",
+        "qs": "4.0.0",
+        "range-parser": "1.0.3",
+        "send": "0.13.1",
+        "serve-static": "1.10.3",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.0",
+        "vary": "1.0.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+      "integrity": "sha1-haF8bFmpRxfSYtYSMNSw6+PUoU0=",
+      "requires": {
+        "debug": "2.2.0",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "unpipe": "1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+      "integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
+    },
+    "http-errors": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+      "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+      "requires": {
+        "inherits": "2.0.3",
+        "statuses": "1.5.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+      "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+    },
+    "negotiator": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+      "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+      "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.0.5"
+      }
+    },
+    "qs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+      "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4="
+    },
+    "range-parser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+      "integrity": "sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU="
+    },
+    "raw-body": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+      "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+        }
+      }
+    },
+    "send": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+      "integrity": "sha1-ow1fTILIqbrprQCh2bG9vm8Zntc=",
+      "requires": {
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "escape-html": "1.0.3",
+        "etag": "1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "2.3.0",
+        "range-parser": "1.0.3",
+        "statuses": "1.2.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+      "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
+      "requires": {
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.13.2"
+      },
+      "dependencies": {
+        "send": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+          "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
+          "requires": {
+            "debug": "2.2.0",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "escape-html": "1.0.3",
+            "etag": "1.7.0",
+            "fresh": "0.3.0",
+            "http-errors": "1.3.1",
+            "mime": "1.3.4",
+            "ms": "0.7.1",
+            "on-finished": "2.3.0",
+            "range-parser": "1.0.3",
+            "statuses": "1.2.1"
+          }
+        },
+        "statuses": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+          "integrity": "sha1-3e1FzBglbVHtQK7BQkidXGECbSg="
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "vary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+      "integrity": "sha1-meSYFWaihhGN+yuBc1ffeZM3bRA="
+    }
+  }
+}

--- a/eg/persistence/bot.js
+++ b/eg/persistence/bot.js
@@ -3,8 +3,9 @@
 
 // Run this demo: `node bot.js`
 
+require("babel-polyfill");
 var readline = require("readline"),
-    fs = require("fs");
+	fs = require("fs");
 
 // This would just be require("rivescript") if not for running this
 // example from within the RiveScript project.
@@ -14,68 +15,76 @@ var RiveScript = require("../../lib/rivescript");
 // and persists user data to disk as a local file named "./$USERNAME.json"
 // where $USERNAME is the username.
 function getReply(bot, username, message) {
-    var filename = "./" + username + ".json";
+	var filename = "./" + username + ".json";
 
-    // See if the bot knows this user yet (in its current memory).
-    var userData = bot.getUservars(username);
-    if (!userData) {
-        // See if a local file exists for stored user variables.
-        try {
-            var stats = fs.statSync(filename);
-            if (stats) {
-                var jsonText = fs.readFileSync(filename);
-                userData = JSON.parse(jsonText);
-                bot.setUservars(username, userData);
-            }
-        } catch(e) {}
-    }
+	// See if the bot knows this user yet (in its current memory).
+	var userData = bot.getUservars(username);
+	if (!userData) {
+		// See if a local file exists for stored user variables.
+		try {
+			var stats = fs.statSync(filename);
+			if (stats) {
+				var jsonText = fs.readFileSync(filename);
+				userData = JSON.parse(jsonText);
+				bot.setUservars(username, userData);
+			}
+		} catch(e) {}
+	}
 
-    // Get a reply.
-    var reply = bot.reply(username, message);
+	// Wrap the reply promise so we can export user variables before
+	// we return it up the stack.
+	return new Promise(function(resolve, reject) {
+		bot.reply(username, message).then(function(reply) {
+			// Export user variables to disk.
+			userData = bot.getUservars(username);
+			fs.writeFile(filename, JSON.stringify(userData, null, 2), function(err) {
+				if (err) {
+					console.error("Failed to write file", filename, err);
+				}
+			});
 
-    // Export user variables to disk.
-    userData = bot.getUservars(username);
-    fs.writeFile(filename, JSON.stringify(userData, null, 2), function(err) {
-        if (err) {
-            console.error("Failed to write file", filename, err);
-        }
-    });
-
-    return reply;
+			resolve(reply);
+		}).catch(reject);
+	})
 }
 
 var rs = new RiveScript();
-rs.loadDirectory("../brain", function() {
-    rs.sortReplies();
+rs.loadDirectory("../brain").then(function() {
+	rs.sortReplies();
 
-    var rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
+	var rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
 
-    rl.question("Enter your username [default: soandso]: ", function(username) {
-        if (!username) {
-            username = "soandso";
-        }
+	rl.question("Enter your username [default: soandso]: ", function(username) {
+		if (!username) {
+			username = "soandso";
+		}
 
-        console.log("Hello", username);
-        console.log("Type /quit to quit.\n");
+		console.log("Hello", username);
+		console.log("Type /quit to quit.\n");
 
-        rl.setPrompt("> ");
-        rl.prompt();
-        rl.on("line", function(cmd) {
-            // Handle commands.
-            if (cmd === "/quit") {
-                process.exit(0);
-            } else {
-                // Get a reply from the bot.
-                var reply = getReply(rs, username, cmd);
-                console.log("Bot>", reply);
-            }
-
-            rl.prompt();
-        }).on("close", function() {
-            process.exit(0);
-        });
-    })
+		rl.setPrompt("> ");
+		rl.prompt();
+		rl.on("line", function(cmd) {
+			// Handle commands.
+			if (cmd === "/quit") {
+				process.exit(0);
+			} else {
+				// Get a reply from the bot.
+				getReply(rs, username, cmd).then(function(reply) {
+					console.log("Bot>", reply);
+					rl.prompt();
+				}).catch(function(err) {
+					console.log("Err>", err);
+					rl.prompt();
+				});
+			}
+		}).on("close", function() {
+			process.exit(0);
+		});
+	})
+}).catch(function(err) {
+	console.error(err);
 });

--- a/eg/quickblox-bot/index.js
+++ b/eg/quickblox-bot/index.js
@@ -6,6 +6,7 @@
 //
 // Run this demo: `node index.js`
 
+require("babel-polyfill");
 const QB = require('quickblox');
 
 // This would just be require("rivescript") if not for running this
@@ -23,155 +24,161 @@ const RiveScript = require("../../lib/rivescript");
 // new user for you chat bot. Then put here user's ID, password, login and full name.
 //
 const CONFIG = {
-    "appId": "...",
-    "authKey": "...",
-    "authSecret": "...",
-    "user": {
-        "id": "...",
-        "login": "...",
-        "password": "...",
-        "fullname": "..."
-    }
+	"appId": "...",
+	"authKey": "...",
+	"authSecret": "...",
+	"user": {
+		"id": "...",
+		"login": "...",
+		"password": "...",
+		"fullname": "..."
+	}
 };
 
 // Init RiveScript logic
 var riveScriptGenerator = new RiveScript();
 
 function loadingDone(batch_num) {
-    console.log(`[RiveScript] Batch #${batch_num} has finished loading!`);
-    riveScriptGenerator.sortReplies();
+	console.log(`[RiveScript] Batch #${batch_num} has finished loading!`);
+	riveScriptGenerator.sortReplies();
 }
 
 function loadingError(batch_num, error) {
-    console.log(`[RiveScript] Load the batch #${batch_num} is failed`, JSON.stringify(error));
+	console.log(`[RiveScript] Load the batch #${batch_num} is failed`, JSON.stringify(error));
 }
 
-riveScriptGenerator.loadDirectory('../brain', loadingDone, loadingError);
+riveScriptGenerator.loadDirectory('../brain').then(loadingDone).catch(loadingError);
 
 
 // Initialise QuickBlox
 QB.init(CONFIG.appId, CONFIG.authKey, CONFIG.authSecret);
 
 var qbListeners = {
-    // Contact list listener
-    onSubscribeListener: function onSubscribeListener(userId) {
-        console.log(`[QB] onSubscribeListener. Subscribe from ${userId}`);
+	// Contact list listener
+	onSubscribeListener: function onSubscribeListener(userId) {
+		console.log(`[QB] onSubscribeListener. Subscribe from ${userId}`);
 
-        QB.chat.roster.confirm(userId, function() {
-            console.log(`[QB] Confirm subscription from user ${userId}`);
-        });
-    },
+		QB.chat.roster.confirm(userId, function() {
+			console.log(`[QB] Confirm subscription from user ${userId}`);
+		});
+	},
 
-    // System messages listener
-    onSystemMessageListener: function onSystemMessageListener(msg) {
-        if(msg.extension.notification_type === '1'){
-            console.log(`[QB] The user ${msg.userId} adds you to dialog`);
+	// System messages listener
+	onSystemMessageListener: function onSystemMessageListener(msg) {
+		if(msg.extension.notification_type === '1'){
+			console.log(`[QB] The user ${msg.userId} adds you to dialog`);
 
-            var roomJid = QB.chat.helpers.getRoomJidFromDialogId(msg.extension.dialog_id);
+			var roomJid = QB.chat.helpers.getRoomJidFromDialogId(msg.extension.dialog_id);
 
-            QB.chat.muc.join(roomJid);
-        }
-    },
+			QB.chat.muc.join(roomJid);
+		}
+	},
 
-    // Chat messages listener
-    onMessageListener: function onMessageListener(userId, msg) {
-        var answer;
+	// Chat messages listener
+	onMessageListener: function onMessageListener(userId, msg) {
+		var answer;
 
-        // process group chat messages
-        if (msg.type == 'groupchat') {
+		// process group chat messages
+		if (msg.type == 'groupchat') {
 
-            // - skip own messages in the group chat, don't replay to them
-            // - reply only when someone mentions you. For example: "@YourBotBestFriend how are you?"
-            var mentionStartIndex = -1;
-            var mentionPattern = '@' + CONFIG.user.fullname;
-            var mentionLength = mentionPattern.length;
+			// - skip own messages in the group chat, don't replay to them
+			// - reply only when someone mentions you. For example: "@YourBotBestFriend how are you?"
+			var mentionStartIndex = -1;
+			var mentionPattern = '@' + CONFIG.user.fullname;
+			var mentionLength = mentionPattern.length;
 
-            if(msg.body){
-                mentionStartIndex = msg.body.indexOf(mentionPattern);
-            }
+			if(msg.body){
+				mentionStartIndex = msg.body.indexOf(mentionPattern);
+			}
 
-            if(userId != CONFIG.user.id && mentionStartIndex >= 0){
-                // build a reply
-                var realBody;
+			if(userId != CONFIG.user.id && mentionStartIndex >= 0){
+				// build a reply
+				var realBody;
 
-                if(mentionStartIndex === 0 && msg.body.substring(mentionLength, mentionLength+1) == ' '){
-                    realBody = msg.body.substring(mentionLength + 1);
-                }else{
-                    realBody = "What's up? I react only for commands like this: '@YourBotBestFriend <text>'";
-                }
+				if(mentionStartIndex === 0 && msg.body.substring(mentionLength, mentionLength+1) == ' '){
+					realBody = msg.body.substring(mentionLength + 1);
+				}else{
+					realBody = "What's up? I react only for commands like this: '@YourBotBestFriend <text>'";
+				}
 
-                answer = {
-                    type: 'groupchat',
-                    body: riveScriptGenerator.reply(userId, realBody),
-                    extension: {
-                        save_to_history: 1
-                    }
-                };
+				riveScriptGenerator.reply(userId, realBody).then(function(reply) {
+					answer = {
+						type: 'groupchat',
+						body: reply,
+						extension: {
+							save_to_history: 1
+						}
+					};
 
-                QB.chat.send(QB.chat.helpers.getRoomJidFromDialogId(msg.dialog_id), answer);
-            }
+					QB.chat.send(QB.chat.helpers.getRoomJidFromDialogId(msg.dialog_id), answer);
+				});
 
-        // process 1-1 messages
-        } else if (msg.type == 'chat') {
-            if(msg.body){
-                answer = {
-                    type: 'chat',
-                    body: riveScriptGenerator.reply(userId, msg.body),
-                    extension: {
-                        save_to_history: 1
-                    }
-                };
+			}
 
-                QB.chat.send(userId, answer);
-            }
-        }
-    }
- };
+			// process 1-1 messages
+		} else if (msg.type == 'chat') {
+			if(msg.body){
+				riveScriptGenerator.reply(userId, msg.body).then(function(reply) {
+					answer = {
+						type: 'chat',
+						body: reply,
+						extension: {
+							save_to_history: 1
+						}
+					};
+
+					QB.chat.send(userId, answer);
+				})
+
+			}
+		}
+	}
+};
 
 // Create QuickBlox session
 QB.createSession({
-  login: CONFIG.user.login,
-  password: CONFIG.user.password
+	login: CONFIG.user.login,
+	password: CONFIG.user.password
 }, (createSessionError, res) => {
-    if(createSessionError) {
-        console.error('[QB] createSession is failed', JSON.stringify(createSessionError));
-        process.exit(1);
-    }
+	if(createSessionError) {
+		console.error('[QB] createSession is failed', JSON.stringify(createSessionError));
+		process.exit(1);
+	}
 
-    // Connect to Real-Time Chat
-    QB.chat.connect({
-        userId: CONFIG.user.id,
-        password: CONFIG.user.password
-    }, (chatConnectError) => {
-        if (chatConnectError) {
-            console.log('[QB] chat.connect is failed', JSON.stringify(chatConnectError));
-            process.exit(1);
-        }
+	// Connect to Real-Time Chat
+	QB.chat.connect({
+		userId: CONFIG.user.id,
+		password: CONFIG.user.password
+	}, (chatConnectError) => {
+		if (chatConnectError) {
+			console.log('[QB] chat.connect is failed', JSON.stringify(chatConnectError));
+			process.exit(1);
+		}
 
-        console.log('[QB] bot is up and running');
+		console.log('[QB] bot is up and running');
 
-        // Retireve all group chats where bot is in occupants list.
-        QB.chat.dialog.list({type: 2}, (dialogListError, dialogList) => {
-            if(dialogListError){
-                console.log('[QB] dialog.list is failed', JSON.stringify(dialogListError));
-                process.exit(1);
-            }
+		// Retireve all group chats where bot is in occupants list.
+		QB.chat.dialog.list({type: 2}, (dialogListError, dialogList) => {
+			if(dialogListError){
+				console.log('[QB] dialog.list is failed', JSON.stringify(dialogListError));
+				process.exit(1);
+			}
 
-            // Join bot's group chats
-            dialogList.items.forEach((dialog) => {
-                QB.chat.muc.join(dialog.xmpp_room_jid);
-            });
-        });
+			// Join bot's group chats
+			dialogList.items.forEach((dialog) => {
+				QB.chat.muc.join(dialog.xmpp_room_jid);
+			});
+		});
 
-        // Add listeners
-        QB.chat.onMessageListener = qbListeners.onMessageListener;
-        QB.chat.onSubscribeListener = qbListeners.onSubscribeListener;
-        QB.chat.onSystemMessageListener = qbListeners.onSystemMessageListener;
-    });
-  }
+		// Add listeners
+		QB.chat.onMessageListener = qbListeners.onMessageListener;
+		QB.chat.onSubscribeListener = qbListeners.onSubscribeListener;
+		QB.chat.onSystemMessageListener = qbListeners.onSystemMessageListener;
+	});
+}
 );
 
 process.on('exit', function () {
-    console.log('The qbot is gone.');
-    QB.chat.disconnect();
+	console.log('The qbot is gone.');
+	QB.chat.disconnect();
 });

--- a/eg/quickblox-bot/package-lock.json
+++ b/eg/quickblox-bot/package-lock.json
@@ -1,0 +1,1071 @@
+{
+  "name": "quickblox-bot",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@xmpp/jid": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.0.1.tgz",
+      "integrity": "sha1-yCw8ttf9dmN/L5euwuDGiUKqsKE="
+    },
+    "@xmpp/streamparser": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@xmpp/streamparser/-/streamparser-0.0.6.tgz",
+      "integrity": "sha1-EYAz6p23yGoctGED8mnr/3n28eo=",
+      "requires": {
+        "@xmpp/xml": "0.1.3",
+        "inherits": "2.0.3",
+        "ltx": "2.7.1"
+      },
+      "dependencies": {
+        "@xmpp/xml": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.1.3.tgz",
+          "integrity": "sha1-HxQ5nlPkGWiFWGmPbGLnHjmoam4=",
+          "requires": {
+            "inherits": "2.0.3",
+            "ltx": "2.7.1"
+          }
+        }
+      }
+    },
+    "@xmpp/xml": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.0.1.tgz",
+      "integrity": "sha1-Lk4Q6rvT93v15TVqU/IxKTyBsAI=",
+      "requires": {
+        "inherits": "2.0.3",
+        "ltx": "2.7.1"
+      }
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "backoff": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+      "integrity": "sha1-7nx+OAk/kuRyhZ22NedlJFT8Ieo="
+    },
+    "base64-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+      "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "1.6.16"
+      }
+    },
+    "browser-request": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
+      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "crypto-js": {
+      "version": "3.1.2-2",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.2-2.tgz",
+      "integrity": "sha1-kydPF0jsqC5EQHRTboM8Ijwo8Ok="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.23"
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "requires": {
+        "accepts": "1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.4.0",
+        "type-is": "1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.2",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.16"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": "1.4.0"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "express-ws": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-0.2.6.tgz",
+      "integrity": "sha1-avKnA02y82DN2UAzR8q/UlPCeeg=",
+      "requires": {
+        "url-join": "0.0.1",
+        "ws": "0.4.32"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.4.0",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
+    "ltx": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/ltx/-/ltx-2.7.1.tgz",
+      "integrity": "sha1-Dly9y1vxeM+ngx6kHcMj2XQiMVo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "ltx-ea": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ltx-ea/-/ltx-ea-2.5.1.tgz",
+      "integrity": "sha1-+UMlR3GqEo3q1p7FINz/Ot1trQM=",
+      "requires": {
+        "inherits": "2.0.3",
+        "node-event-emitter": "0.0.1"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "nan": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
+      "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
+    },
+    "nativescript-websockets": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nativescript-websockets/-/nativescript-websockets-1.5.0.tgz",
+      "integrity": "sha512-f/46nnVAuhGG+92ARMIdIIiLZ6+byZwcptweJibGeWN0+63DgHD0M6AqSvVQghOLxZTRWQB75dU0gIXm3H8IIA=="
+    },
+    "nativescript-xmpp-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nativescript-xmpp-client/-/nativescript-xmpp-client-1.2.0.tgz",
+      "integrity": "sha1-O7TZbZsDMr+sJ4GuQlhbMaeB1v4=",
+      "requires": {
+        "@xmpp/jid": "0.0.1",
+        "@xmpp/xml": "0.0.1",
+        "base64-js": "1.2.0",
+        "debug": "2.6.9",
+        "inherits": "2.0.3",
+        "ltx-ea": "2.5.1",
+        "md5.js": "1.3.4",
+        "nativescript-websockets": "1.5.0",
+        "net-browserify": "0.2.4",
+        "util": "0.10.4"
+      }
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "net-browserify": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/net-browserify/-/net-browserify-0.2.4.tgz",
+      "integrity": "sha1-64mOLr0a/OiVcfJgtPGHAYqi8qk=",
+      "requires": {
+        "body-parser": "1.18.3",
+        "express": "4.16.3",
+        "express-ws": "0.2.6"
+      }
+    },
+    "node-event-emitter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/node-event-emitter/-/node-event-emitter-0.0.1.tgz",
+      "integrity": "sha1-i1lzd9eaHZdvfUX5FtPTZD1z+M4="
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "node-xmpp-client": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/node-xmpp-client/-/node-xmpp-client-3.2.0.tgz",
+      "integrity": "sha1-r0Un3wzFq9JpDLohOcwezcgeoYk=",
+      "requires": {
+        "browser-request": "0.3.3",
+        "debug": "2.6.9",
+        "md5.js": "1.3.4",
+        "minimist": "1.2.0",
+        "node-xmpp-core": "5.0.9",
+        "request": "2.87.0",
+        "ws": "1.1.5"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
+        }
+      }
+    },
+    "node-xmpp-core": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/node-xmpp-core/-/node-xmpp-core-5.0.9.tgz",
+      "integrity": "sha1-XCjCjtsfs/i+uixnYHd2E/SPNCo=",
+      "requires": {
+        "@xmpp/jid": "0.0.2",
+        "@xmpp/streamparser": "0.0.6",
+        "@xmpp/xml": "0.1.3",
+        "debug": "2.6.9",
+        "inherits": "2.0.3",
+        "lodash.assign": "4.2.0",
+        "node-xmpp-tls-connect": "1.0.1",
+        "reconnect-core": "https://github.com/dodo/reconnect-core/tarball/merged"
+      },
+      "dependencies": {
+        "@xmpp/jid": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/@xmpp/jid/-/jid-0.0.2.tgz",
+          "integrity": "sha1-DVKMqdWNr8gzZlVk/+YvMyoxZ/I="
+        },
+        "@xmpp/xml": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/@xmpp/xml/-/xml-0.1.3.tgz",
+          "integrity": "sha1-HxQ5nlPkGWiFWGmPbGLnHjmoam4=",
+          "requires": {
+            "inherits": "2.0.3",
+            "ltx": "2.7.1"
+          }
+        }
+      }
+    },
+    "node-xmpp-tls-connect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-xmpp-tls-connect/-/node-xmpp-tls-connect-1.0.1.tgz",
+      "integrity": "sha1-kazkOsJrE4hhsr5HjfnfGdYdxcM="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "proxy-addr": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "requires": {
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "quickblox": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/quickblox/-/quickblox-2.12.0.tgz",
+      "integrity": "sha512-F0xgG+T5kUtc4tGpWYXzsjf7OyZzNaMcBoOMrzURdyi1RrhGByKPc60IlY+e/p2WvlprfSXgcSzr5k5rRvVMxQ==",
+      "requires": {
+        "crypto-js": "3.1.2-2",
+        "form-data": "2.3.2",
+        "nativescript-xmpp-client": "1.2.0",
+        "node-fetch": "1.7.3",
+        "node-xmpp-client": "3.2.0",
+        "sdp-transform": "2.4.1",
+        "strophe.js": "1.2.12",
+        "webrtc-adapter": "5.0.6"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "reconnect-core": {
+      "version": "https://github.com/dodo/reconnect-core/tarball/merged",
+      "integrity": "sha512-wZK/v5ZaNaSUs2Wnwh2YSX/Jqv6bQHKNEwojdzV11tByKziR9ikOssf5tvUhx+8/oCBz6AakOFAjZuqPoiRHJQ==",
+      "requires": {
+        "backoff": "2.3.0"
+      }
+    },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      }
+    },
+    "rtcpeerconnection-shim": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.13.tgz",
+      "integrity": "sha512-Xz4zQLZNs9lFBvqbaHGIjLWtyZ1V82ec5r+WNEo7NlIx3zF5M3ytn9mkkfYeZmpE032cNg3Vvf0rP8kNXUNd9w==",
+      "requires": {
+        "sdp": "2.7.4"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sdp": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.7.4.tgz",
+      "integrity": "sha512-0+wTfgvUUEGcvvFoHIC0aiGbx6gzwAUm8FkKt5Oqqkjf9mEEDLgwnoDKX7MYTGXrNNwzikVbutJ+OVNAGmJBQw=="
+    },
+    "sdp-transform": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.4.1.tgz",
+      "integrity": "sha512-dCReSJ6NtCW6goKkKBEHcIknBS1pKejnMw+S3p3jl0PALPFrbjbreCyQ+CABtFxl2GXD2/05+C2q2gZP23dUWQ=="
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "strophe.js": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/strophe.js/-/strophe.js-1.2.12.tgz",
+      "integrity": "sha1-YUK2fJXQK7kzj1IzxuwxuW3QrA0="
+    },
+    "tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g="
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    },
+    "webrtc-adapter": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-5.0.6.tgz",
+      "integrity": "sha512-dh2hPQFOPP0tLEYlFxtGI5vuQmRqkOdYni5wMKUHIx5I2dw0TJ1HdG7P+UechRWt6TvwPWhtbjVNQcQf1KXJmQ==",
+      "requires": {
+        "rtcpeerconnection-shim": "1.2.13",
+        "sdp": "2.7.4"
+      }
+    },
+    "ws": {
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
+      "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI=",
+      "requires": {
+        "commander": "2.1.0",
+        "nan": "1.0.0",
+        "options": "0.0.6",
+        "tinycolor": "0.0.1"
+      }
+    }
+  }
+}

--- a/eg/reply-async/package-lock.json
+++ b/eg/reply-async/package-lock.json
@@ -1,0 +1,335 @@
+{
+  "name": "rive-weatherman",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "colors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    }
+  }
+}

--- a/eg/reply-async/weatherman.js
+++ b/eg/reply-async/weatherman.js
@@ -3,6 +3,7 @@
 
 // Run this demo: `node weatherman.js`
 
+require("babel-polyfill");
 var readline = require("readline");
 var request = require("request");
 var colors = require('colors');
@@ -17,117 +18,115 @@ var RiveScript = require("../../lib/rivescript");
 var rs = new RiveScript();
 
 var getWeather = function(location, callback) {
-  request.get({
-    url: "http://api.openweathermap.org/data/2.5/weather",
-    qs: {
-      q: location,
-      APPID: APPID
-    },
-    json: true
-  }, function(error, response) {
-    if (response.statusCode !== 200) {
-      callback.call(this, response.body);
-    } else {
-      callback.call(this, null, response.body);
-    }
-  });
+	request.get({
+		url: "http://api.openweathermap.org/data/2.5/weather",
+		qs: {
+			q: location,
+			APPID: APPID
+		},
+		json: true
+	}, function(error, response) {
+		if (response.statusCode !== 200) {
+			callback.call(this, response.body);
+		} else {
+			callback.call(this, null, response.body);
+		}
+	});
 };
 
 
 rs.setSubroutine("getWeather", function (rs, args)  {
-  return new rs.Promise(function(resolve, reject) {
-    getWeather(args.join(' '), function(error, data){
-      if(error) {
-        reject(error);
-      } else {
-        resolve(data.weather[0].description);
-      }
-    });
-  });
+	return new rs.Promise(function(resolve, reject) {
+		getWeather(args.join(' '), function(error, data){
+			if(error) {
+				reject(error);
+			} else {
+				resolve(data.weather[0].description);
+			}
+		});
+	});
 });
 
 rs.setSubroutine("checkForRain", function(rs, args) {
-  return new rs.Promise(function(resolve, reject) {
-    getWeather(args.join(' '), function(error, data){
-      if(error) {
-        console.error('');
-        reject(error);
-      } else {
-        var rainStatus = data.rain ? 'yup :(' : 'nope';
-        resolve(rainStatus);
-      }
-    });
-  });
+	return new rs.Promise(function(resolve, reject) {
+		getWeather(args.join(' '), function(error, data){
+			if(error) {
+				console.error('');
+				reject(error);
+			} else {
+				var rainStatus = data.rain ? 'yup :(' : 'nope';
+				resolve(rainStatus);
+			}
+		});
+	});
 });
 
 // Create a prototypical class for our own chatbot.
 var AsyncBot = function(onReady) {
-    var self = this;
+	var self = this;
 
-    if (APPID === 'change me') {
-        console.log('Error -- edit weatherman.js and provide the APPID for Open Weathermap.'.bold.yellow);
-    }
+	if (APPID === 'change me') {
+		console.log('Error -- edit weatherman.js and provide the APPID for Open Weathermap.'.bold.yellow);
+	}
 
-    // Load the replies and process them.
-    rs.loadFile("weatherman.rive", function() {
-      rs.sortReplies();
-      onReady();
-    });
+	// Load the replies and process them.
+	rs.loadFile("weatherman.rive").then(function() {
+		rs.sortReplies();
+		onReady();
+	}).catch(function(err) {
+		console.error(err);
+	});
 
-    // This is a function for delivering the message to a user. Its actual
-    // implementation could vary; for example if you were writing an IRC chatbot
-    // this message could deliver a private message to a target username.
-    self.sendMessage = function(username, message) {
-      // This just logs it to the console like "[Bot] @username: message"
-      console.log(
-        ["[Brick Tamland]", message].join(": ").underline.green
-      );
-    };
+	// This is a function for delivering the message to a user. Its actual
+	// implementation could vary; for example if you were writing an IRC chatbot
+	// this message could deliver a private message to a target username.
+	self.sendMessage = function(username, message) {
+		// This just logs it to the console like "[Bot] @username: message"
+		console.log(
+			["[Brick Tamland]", message].join(": ").underline.green
+		);
+	};
 
-    // This is a function for a user requesting a reply. It just proxies through
-    // to RiveScript.
-    self.getReply = function(username, message, callback) {
-      return rs.replyAsync(username, message, self).then(function(reply){
-        callback.call(this, null, reply);
-      }).catch(function(error) {
-        callback.call(this, error);
-      });
-    }
+	// This is a function for a user requesting a reply. It just proxies through
+	// to RiveScript.
+	self.getReply = function(username, message, callback) {
+		return rs.reply(username, message, self);
+	}
 };
 
 // Create and run the example bot.
 var bot = new AsyncBot(function() {
-  // Drop into an interactive shell to get replies from the user.
-  // If this were something like an IRC bot, it would have a message
-  // handler from the server for when a user sends a private message
-  // to the bot's nick.
-  var rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout
-  });
+	// Drop into an interactive shell to get replies from the user.
+	// If this were something like an IRC bot, it would have a message
+	// handler from the server for when a user sends a private message
+	// to the bot's nick.
+	var rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
 
-  rl.setPrompt("> ");
-  rl.prompt();
-  rl.on("line", function(cmd) {
-    // If this was an IRC bot, imagine "nick" came from the server as the
-    // sending user's IRC nickname.
-    nick = "Soandso";
-    console.log("[" + nick + "] " + cmd);
+	rl.setPrompt("> ");
+	rl.prompt();
+	rl.on("line", function(cmd) {
+		// If this was an IRC bot, imagine "nick" came from the server as the
+		// sending user's IRC nickname.
+		nick = "Soandso";
+		console.log("[" + nick + "] " + cmd);
 
-    // Handle commands.
-    if (cmd === "/quit") {
-      process.exit(0);
-    } else {
-      reply = bot.getReply(nick, cmd, function(error, reply){
-        if (error) {
-          bot.sendMessage(nick, "Oops. The weather service is not cooperating!");
-        } else {
-          bot.sendMessage(nick, reply);
-        }
-        rl.prompt();
-      });
-    }
-  }).on("close", function() {
-    process.exit(0);
-  });
+		// Handle commands.
+		if (cmd === "/quit") {
+			process.exit(0);
+		} else {
+			bot.getReply(nick, cmd).then(function(reply) {
+				bot.sendMessage(nick, reply);
+				rl.prompt();
+			}).catch(function(err) {
+				console.error(err);
+				bot.sendMessage(nick, "Oops. The weather service is not cooperating!");
+				rl.prompt();
+			});
+		}
+	}).on("close", function() {
+		process.exit(0);
+	});
 });

--- a/eg/router/router.js
+++ b/eg/router/router.js
@@ -2,6 +2,7 @@
 //
 // See the README.md for information.
 
+require("babel-polyfill");
 var RiveScript = require("../../lib/rivescript"),
 	readline = require("readline");
 
@@ -116,11 +117,14 @@ rl.on("line", function(cmd) {
 		process.exit(0);
 	} else {
 		// Get a reply from the bot.
-		var reply = rs.reply("localuser", cmd);
-		console.log("Bot>", reply);
+		rs.reply("localuser", cmd).then(function(reply) {
+			console.log("Bot>", reply);
+			rl.prompt();
+		}).catch(function(err) {
+			console.log("Err>", err);
+			rl.prompt();
+		});
 	}
-
-	rl.prompt();
 }).on("close", function() {
 	process.exit(0);
 });

--- a/eg/scope/bot.js
+++ b/eg/scope/bot.js
@@ -3,6 +3,7 @@
 
 // Run this demo: `node bot.js`
 
+require("babel-polyfill");
 var readline = require("readline");
 
 // This would just be require("rivescript") if not for running this
@@ -11,62 +12,66 @@ var RiveScript = require("../../lib/rivescript");
 
 // Create a prototypical class for our own chatbot.
 var ScopedBot = function(onReady) {
-    // Because `this` changes with each function call in JS, it's good practice
-    // to alias it as `self` so that sub-functions can still refer to the parent
-    // scope.
-    var self = this;
-    self.rs = new RiveScript();
+	// Because `this` changes with each function call in JS, it's good practice
+	// to alias it as `self` so that sub-functions can still refer to the parent
+	// scope.
+	var self = this;
+	self.rs = new RiveScript();
 
-    // Set some private instance attributes that the macro can read and edit.
-    self.hello   = "Hello world";
-    self.counter = 0;
+	// Set some private instance attributes that the macro can read and edit.
+	self.hello   = "Hello world";
+	self.counter = 0;
 
-    // Load the replies and process them.
-    self.rs.loadFile("scope.rive", function() {
-        self.rs.sortReplies();
-        onReady();
-    });
+	// Load the replies and process them.
+	self.rs.loadFile("scope.rive").then(function() {
+		self.rs.sortReplies();
+		onReady();
+	}).catch(function(err) {
+		console.error(err);
+	});
 
-    // This is a function for a user requesting a reply. It just proxies through
-    // to RiveScript.
-    self.getReply = function(username, message) {
-        // When we call RiveScript's getReply(), we pass `self` as the scope
-        // variable which points back to this ScopedBot object. This way, JS
-        // object macros from the RiveScript code are able to reference this
-        // bot object using `this` and call other functions and variables.
-        return self.rs.reply(username, message, self);
-    };
+	// This is a function for a user requesting a reply. It just proxies through
+	// to RiveScript.
+	self.getReply = function(username, message) {
+		// When we call RiveScript's getReply(), we pass `self` as the scope
+		// variable which points back to this ScopedBot object. This way, JS
+		// object macros from the RiveScript code are able to reference this
+		// bot object using `this` and call other functions and variables.
+		return self.rs.reply(username, message, self);
+	};
 
-    // This function is available on the `this` object to macros
-    self.PrivateFunction = function() {
-        return "It works!";
-    };
+	// This function is available on the `this` object to macros
+	self.PrivateFunction = function() {
+		return "It works!";
+	};
 };
 
 // Create and run the example bot.
 var bot = new ScopedBot(function() {
-    // Set up a reader for the standard input for chatting with the bot in your
-    // terminal window.
-    var rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
+	// Set up a reader for the standard input for chatting with the bot in your
+	// terminal window.
+	var rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
 
-    rl.setPrompt("> ");
-    rl.prompt();
-    rl.on("line", function(cmd) {
-        // Handle commands.
-        if (cmd === "/quit") {
-            process.exit(0);
-        } else {
-            // Get a reply from the bot.
-            var reply = bot.getReply("soandso", cmd);
-        }
-
-        console.log("Bot>", reply);
-
-        rl.prompt();
-    }).on("close", function() {
-        process.exit(0);
-    });
+	rl.setPrompt("> ");
+	rl.prompt();
+	rl.on("line", function(cmd) {
+		// Handle commands.
+		if (cmd === "/quit") {
+			process.exit(0);
+		} else {
+			// Get a reply from the bot.
+			bot.getReply("soandso", cmd).then(function(reply) {
+				console.log("Bot>", reply);
+				rl.prompt();
+			}).catch(function(err) {
+				console.log("Err>", err);
+				rl.prompt();
+			});
+		}
+	}).on("close", function() {
+		process.exit(0);
+	});
 });

--- a/eg/second-reply/bot.js
+++ b/eg/second-reply/bot.js
@@ -3,6 +3,7 @@
 
 // Run this demo: `node bot.js`
 
+require("babel-polyfill");
 var readline = require("readline");
 
 // This would just be require("rivescript") if not for running this
@@ -11,64 +12,69 @@ var RiveScript = require("../../lib/rivescript");
 
 // Create a prototypical class for our own chatbot.
 var MyBot = function(onReady) {
-    var self = this;
-    self.rs = new RiveScript();
+	var self = this;
+	self.rs = new RiveScript();
 
-    // Load the replies and process them.
-    self.rs.loadFile("second-reply.rive", function() {
-        self.rs.sortReplies();
-        onReady();
-    });
+	// Load the replies and process them.
+	self.rs.loadFile("second-reply.rive").then(function() {
+		self.rs.sortReplies();
+		onReady();
+	}).catch(function(err) {
+		console.error(err);
+	});
 
-    // This is a function for delivering the message to a user. Its actual
-    // implementation could vary; for example if you were writing an IRC chatbot
-    // this message could deliver a private message to a target username.
-    self.sendMessage = function(username, message) {
-        // This just logs it to the console like "[Bot] @username: message"
-        console.log("[Bot] @"+username+": "+message);
-    };
+	// This is a function for delivering the message to a user. Its actual
+	// implementation could vary; for example if you were writing an IRC chatbot
+	// this message could deliver a private message to a target username.
+	self.sendMessage = function(username, message) {
+		// This just logs it to the console like "[Bot] @username: message"
+		console.log("[Bot] @"+username+": "+message);
+	};
 
-    // This is a function for a user requesting a reply. It just proxies through
-    // to RiveScript.
-    self.getReply = function(username, message) {
-        // When we call RiveScript's getReply(), we pass `self` as the scope
-        // variable which points back to this AsyncBot object. This way the
-        // object macro can call `this.sendMessage()` to asynchronously send
-        // a response to the user.
-        return self.rs.reply(username, message, self);
-    }
+	// This is a function for a user requesting a reply. It just proxies through
+	// to RiveScript.
+	self.getReply = function(username, message) {
+		// When we call RiveScript's getReply(), we pass `self` as the scope
+		// variable which points back to this AsyncBot object. This way the
+		// object macro can call `this.sendMessage()` to asynchronously send
+		// a response to the user.
+		return self.rs.reply(username, message, self);
+	}
 };
 
 // Create and run the example bot.
 var bot = new MyBot(function() {
-    // Drop into an interactive shell to get replies from the user.
-    // If this were something like an IRC bot, it would have a message
-    // handler from the server for when a user sends a private message
-    // to the bot's nick.
-    var rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
+	// Drop into an interactive shell to get replies from the user.
+	// If this were something like an IRC bot, it would have a message
+	// handler from the server for when a user sends a private message
+	// to the bot's nick.
+	var rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout
+	});
 
-    rl.setPrompt("> ");
-    rl.prompt();
-    rl.on("line", function(cmd) {
-        // If this was an IRC bot, imagine "nick" came from the server as the
-        // sending user's IRC nickname.
-        nick = "Soandso";
-        console.log("[" + nick + "] " + cmd);
+	rl.setPrompt("> ");
+	rl.prompt();
+	rl.on("line", function(cmd) {
+		// If this was an IRC bot, imagine "nick" came from the server as the
+		// sending user's IRC nickname.
+		nick = "Soandso";
+		console.log("[" + nick + "] " + cmd);
 
-        // Handle commands.
-        if (cmd === "/quit") {
-            process.exit(0);
-        } else {
-            // Get a reply from the bot.
-            var reply = bot.getReply(nick, cmd);
-            bot.sendMessage(nick, reply);
-        }
-
-        rl.prompt();
-    }).on("close", function() {
-        process.exit(0);
-    });
+		// Handle commands.
+		if (cmd === "/quit") {
+			process.exit(0);
+		} else {
+			// Get a reply from the bot.
+			bot.getReply(nick, cmd).then(function(reply) {
+				bot.sendMessage(nick, reply);
+				rl.prompt();
+			}).catch(function(err) {
+				bot.sendMessage(nick, "Error: " + err);
+				rl.prompt();
+			});
+		}
+	}).on("close", function() {
+		process.exit(0);
+	});
 });

--- a/eg/slack-bot/package-lock.json
+++ b/eg/slack-bot/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "slack-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "coffee-script": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.3.tgz",
+      "integrity": "sha1-WW5ug/z8tnxZZKtw1ES+/wrASsc="
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY="
+    },
+    "log": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
+    },
+    "nan": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
+      "integrity": "sha1-DfGTXKsVNpB17xYK0olBB6oU3C0="
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+    },
+    "slack-client": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/slack-client/-/slack-client-1.4.1.tgz",
+      "integrity": "sha1-tt5BfiTlzycBCO7RcwzC3ci8ZK8=",
+      "requires": {
+        "coffee-script": "1.9.3",
+        "log": "1.4.0",
+        "ws": "0.4.31"
+      }
+    },
+    "tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
+    },
+    "ws": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+      "integrity": "sha1-WkhJ56nM0e1aga60hHyf7fMSKSc=",
+      "requires": {
+        "commander": "0.6.1",
+        "nan": "0.3.2",
+        "options": "0.0.6",
+        "tinycolor": "0.0.1"
+      }
+    }
+  }
+}

--- a/eg/slack-bot/slackbot.js
+++ b/eg/slack-bot/slackbot.js
@@ -5,6 +5,7 @@
 // To run this bot, edit config.js to fill in your Slack Auth token and other
 // settings for the bot.
 
+require("babel-polyfill");
 var config = require("./config"),
 	RiveScript = require("../../lib/rivescript"),
 	Slack = require("slack-client");
@@ -12,7 +13,7 @@ var config = require("./config"),
 var slack = new Slack(config.token, true, true);
 var rs = new RiveScript();
 
-rs.loadDirectory("../brain", function() {
+rs.loadDirectory("../brain").then(function() {
 	rs.sortReplies();
 	slack.login();
 
@@ -50,20 +51,23 @@ rs.loadDirectory("../brain", function() {
 			).trim();
 
 			// Get the bot's reply.
-			reply = rs.reply(user.name, message);
-
-			// Send it to the channel.
-			channel = slack.getChannelGroupOrDMByID(messageData.channel);
-			if (reply.length > 0) {
-				channel.send(reply);
-			}
+			rs.reply(user.name, message).then(function(reply) {
+				// Send it to the channel.
+				channel = slack.getChannelGroupOrDMByID(messageData.channel);
+				if (reply.length > 0) {
+					channel.send(reply);
+				}
+			});
 		} else if (messageData.channel[0] === "D") {
 			// Direct message.
-			reply = rs.reply(user.name, message);
-			channel = slack.getChannelGroupOrDMByName(user.name);
-			if (reply.length > 0) {
-				channel.send(reply);
-			}
+			rs.reply(user.name, message).then(function(reply) {
+				channel = slack.getChannelGroupOrDMByName(user.name);
+				if (reply.length > 0) {
+					channel.send(reply);
+				}
+			});
 		}
 	});
+}).catch(function(err) {
+	console.error(err);
 })

--- a/eg/telnet-server/tcp-server.js
+++ b/eg/telnet-server/tcp-server.js
@@ -4,16 +4,16 @@
 //
 // Run this and then telnet to localhost:2001 and chat with the bot!
 
+require("babel-polyfill");
 var net        = require("net");
 var RiveScript = require("../../lib/rivescript.js");
 
 // Create the bot.
 var bot = new RiveScript({ debug: false });
-bot.loadDirectory("../brain", success_handler, error_handler);
+bot.loadDirectory("../brain").then(success_handler).catch(error_handler);
 
-function success_handler (loadcount) {
-	console.log("Load #" + loadcount + " completed!");
-
+function success_handler() {
+	console.log("Bot loaded!");
 	bot.sortReplies();
 
 	// Start the TCP server.
@@ -42,13 +42,14 @@ function success_handler (loadcount) {
 				return;
 			}
 
-			var reply = bot.reply(socket.name, message);
-			socket.write("Bot> " + reply + "\n");
-			socket.write("You> ");
+			bot.reply(socket.name, message).then(function(reply) {
+				socket.write("Bot> " + reply + "\n");
+				socket.write("You> ");
 
-			// Log it for the server terminal to see!
-			console.log("[" + socket.name + "] " + message);
-			console.log("[Bot] " + reply + "\n");
+				// Log it for the server terminal to see!
+				console.log("[" + socket.name + "] " + message);
+				console.log("[Bot] " + reply + "\n");
+			});
 		});
 
 		// Handle disconnects.
@@ -60,6 +61,6 @@ function success_handler (loadcount) {
 	console.log("TCP server running on port 2001.\n");
 }
 
-function error_handler (loadcount, err) {
-	console.log("Error loading batch #" + loadcount + ": " + err + "\n");
+function error_handler (err) {
+	console.error(err);
 }

--- a/eg/web-client/README.md
+++ b/eg/web-client/README.md
@@ -8,9 +8,27 @@ features preventing a local web page from accessing other local files, so if you
 open `chat.html` by double-clicking in your file browser it probably won't be
 able to read the `.rive` files the bot needs.
 
-You can use the `grunt server` command from the root of the `rivescript-js`
-project to run a built-in web server for testing this example. Otherwise,
-upload these files to a web server.
+One simple solution is to use the Nodejs `http-server` command:
+
+```bash
+# If you don't already have http-server:
+% npm install -g http-server
+
+# From the root of the rivescript-js project...
+% cd ~/git/rivescript-js
+
+# Build the `dist/rivescript.js` packed for the web browser, and then run
+# the Node http-server.
+% npm run dist
+% http-server
+```
+
+And then visit <http://127.0.0.1:8080/eg/web-client/chat.html> to load the
+web client in your browser.
+
+Another alternative, if you have Python installed (if you're on Mac or Linux,
+you probably do) is to just run `python -m SimpleHTTPServer` from the root
+of the rivescript-js project. Do remember to run `npm run dist` though!
 
 ## Usage: Built-in Server
 

--- a/eg/web-client/chat.css
+++ b/eg/web-client/chat.css
@@ -28,6 +28,11 @@ div#debug {
 	max-height: 450px;
 	width: 100%;
 }
+code {
+	font-family: monospace;
+	font-size: medium;
+	color: #D00;
+}
 span.user {
 	font-weight: bold;
 	color: #0000FF;
@@ -43,13 +48,13 @@ table.input-table {
 	width: 100%;
 }
 table.input-table td.text-box {
-	padding: 4px; 
+	padding: 4px;
 	text-align: left;
-	vertical-align: middle; 
+	vertical-align: middle;
 }
 table.input-table td.send-button {
-	padding: 4px; 
+	padding: 4px;
 	text-align: center;
-	vertical-align: middle; 
+	vertical-align: middle;
 	width: 10px;
 }

--- a/eg/web-client/chat.html
+++ b/eg/web-client/chat.html
@@ -12,6 +12,53 @@
 
 <h1>Chat</h1>
 
+<div id="webpack-error" style="display: none; max-width: 500px">
+	<h2 style="color: #F00">Loading Error: rivescript.js not found</h2>
+
+	<p>
+		There was a problem loading the <code>rivescript.js</code> script on this
+		page. This most likely means the script was not found where this page was
+		expecting it to be. If you're running this demo from the rivescript-js
+		git project, maybe you forgot to run <code>npm run dist</code>?
+	</p>
+
+	<p>
+		The original version of this page looks for it at the relative path
+		<code>../../dist/rivescript.js</code>. This is expecting the path to
+		<em>the current page</em> to be something like <code>/eg/web-client/chat.html</code>
+		from a web server started at the root of the rivescript-js project.
+		Double check that these path settings are correct.
+	</p>
+
+	<p>
+		If you have uploaded the web-client demo to a web server such as Apache,
+		ensure that the path is correct for where it looks for <code>rivescript.js</code>.
+	</p>
+</div>
+<div id="local-file-error" style="display: none; max-width: 500px">
+	<h2 style="color: #F00">Local Filesystem Detected</h2>
+
+	<p>
+		It appears you have opened this page by double-clicking it in your file
+		browser: the URL of this page has a <code>file:///</code> URL scheme.
+	</p>
+
+	<p>
+		Modern web browsers place security restrictions on locally opened web
+		pages which prevent them from running ajax requests for other local
+		files on your disk. Unfortunately, this means that the
+		<code>RiveScript.loadFile()</code> function used on this page will
+		probably not work when you open this page locally.
+	</p>
+
+	<p>
+		See the <code>README.md</code> file for some tips on how to run this
+		page in a web server environment. This will be required for the bot to
+		load the <code>*.rive</code> files in a way that respects the Same
+		Origin Policy enforced by the web browser.
+	</p>
+</div>
+
 <fieldset>
 	<legend>Chat Log</legend>
 	<div id="dialogue"></div>
@@ -54,33 +101,45 @@ if (window.location.search.indexOf("debug=1") > -1) {
 	$("#toggle").val("Enable Debug Mode");
 }
 
-// Create our RiveScript interpreter.
-var rs = new RiveScript({
-	debug:   debugMode,
-	onDebug: onDebug
-});
+// Warn the user if they opened the page locally that it will probably
+// experience ajax errors.
+if (window.location.protocol === "file:") {
+	document.querySelector("#local-file-error").style.display = "block";
+}
 
-// This won't work on the web!
-//rs.loadDirectory("brain");
+// Problem loading rivescript.js?
+var rs;
+if (window.RiveScript === undefined) {
+	document.querySelector("#webpack-error").style.display = "block";
+} else {
+	// Create our RiveScript interpreter.
+	rs = new RiveScript({
+		debug:   debugMode,
+		onDebug: onDebug
+	});
 
-// Load our files from the brain/ folder.
-rs.loadFile([
-	"../brain/begin.rive",
-	"../brain/admin.rive",
-	"../brain/clients.rive",
-	"../brain/eliza.rive",
-	"../brain/myself.rive",
-	"../brain/rpg.rive",
-	"../brain/javascript.rive"
-	], on_load_success, on_load_error);
+	// This won't work on the web!
+	//rs.loadDirectory("brain");
 
-// You can register objects that can then be called
-// using <call></call> syntax
-rs.setSubroutine('fancyJSObject', function(rs, args){
-	// doing complex stuff here
-});
+	// Load our files from the brain/ folder.
+	rs.loadFile([
+		"../brain/begin.rive",
+		"../brain/admin.rive",
+		"../brain/clients.rive",
+		"../brain/eliza.rive",
+		"../brain/myself.rive",
+		"../brain/rpg.rive",
+		"../brain/javascript.rive"
+	]).then(onReady).catch(onError);
 
-function on_load_success () {
+	// You can register objects that can then be called
+	// using <call></call> syntax
+	rs.setSubroutine('fancyJSObject', function(rs, args){
+		// doing complex stuff here
+	});
+}
+
+function onReady() {
 	$("#dialogue").append("<div><span class='bot'>Bot:</span> Welcome, this is RiveScript.js v" + rs.version() + ", ready to chat!");
 	$("#message").removeAttr("disabled");
 	$("#message").attr("placeholder", "Send message");
@@ -90,8 +149,8 @@ function on_load_success () {
 	rs.sortReplies();
 }
 
-function on_load_error (err) {
-	window.alert("Loading error: " + err);
+function onError(err, filename, lineno) {
+	$("#dialogue").append('<div><span class="bot">Error:</span> ' + err + '</div>');
 }
 
 // Handle sending a message to the bot.

--- a/mkdoc.py
+++ b/mkdoc.py
@@ -9,13 +9,13 @@ import re
 import markdown
 
 def main():
-    # Scan for coffee modules.
+    # Scan for JavaScript modules.
     modules = []
     for path, dirs, files in os.walk("src"):
         for f in files:
             module = os.path.join(path, f) \
                 .replace("src/", "") \
-                .replace(".coffee", "") \
+                .replace(".js", "") \
                 .replace("/", ".")
             modules.append(dict(
                 name=module,
@@ -28,19 +28,22 @@ def main():
         in_doc = False
         buf = []
         fh = open(mod["path"], "r")
+        indent = 0
         for line in fh:
-            line = line.strip()
-            if line.startswith("##") and not in_doc:
+            stripped = line.strip()
+            if stripped.startswith("/**") and not in_doc:
                 in_doc = True
+                indent = line.index("/**")
                 continue
-            elif not line.startswith("#") and in_doc:
+            elif stripped.startswith("*/") and in_doc:
                 in_doc = False
                 md.append(to_markdown(buf))
                 buf = []
                 continue
 
             if in_doc:
-                buf.append(re.sub(r'(^#+\s?)|(#+$)', '', line))
+                line = line[indent:].rstrip()
+                buf.append(line)
         fh.close()
 
         # Write the Markdown file.
@@ -63,7 +66,7 @@ def to_markdown(buf):
 
     # Consolodate the header.
     header = []
-    while buf[0].strip():
+    while len(buf) > 0 and buf[0].strip():
         header.append(buf.pop(0).strip())
 
     # Headers that aren't functions are always shown as H1.

--- a/shell.js
+++ b/shell.js
@@ -60,18 +60,12 @@ var rl = readline.createInterface({
 	output: process.stdout
 });
 
-
-var bot = null;
-function loadBot() {
-	bot = new RiveScript({
-		debug:   opts.debug,
-		utf8:    opts.utf8,
-		concat:  "newline",
-	});
-	bot.ready = false;
-	bot.loadDirectory(opts.brain, loadingDone, loadingError);
-}
-loadBot();
+var ready = false;
+var bot = new RiveScript({
+	debug:  opts.debug,
+	utf8:   opts.utf8,
+	concat: "newline",
+});
 
 if (opts.watch) {
 	fs.watch(opts.brain, {recursive: false}, function() {
@@ -116,7 +110,7 @@ rl.on('line', async function(cmd) {
 		process.exit(0);
 	} else {
 		// Get a reply from the bot.
-		if (bot && bot.ready) {
+		if (bot && ready) {
 			var reply = await bot.reply("localuser", cmd);
 			console.log("Bot>", reply);
 		} else {
@@ -130,16 +124,12 @@ rl.on('line', async function(cmd) {
 	process.exit(0);
 });
 
-
-
-function loadingDone(batchNumber) {
+bot.loadDirectory(opts.brain).then(() => {
 	bot.sortReplies();
-	bot.ready = true;
-}
-
-function loadingError(error, batchNumber) {
-	console.error("Loading error: " + error);
-}
+	ready = true;
+}).catch((err) => {
+	console.error("Loading error: " + err);
+});
 
 function help() {
 	console.log("Supported commands:");

--- a/src/brain.js
+++ b/src/brain.js
@@ -949,8 +949,9 @@ class Brain {
 						// We do.
 						output = (await self.master._handlers[lang].call(self.master, obj, args, scope));
 					} catch (error) {
-						e = error;
-						self.warn(e.message);
+						if (error != undefined) {
+							self.warn(error);
+						}
 						output = "[ERR: Error raised by object macro]";
 					}
 				} else {

--- a/src/brain.js
+++ b/src/brain.js
@@ -37,7 +37,7 @@ class Brain {
 	}
 
 	/**
-	Promise reply (string user, string msg[, scope])
+	async reply (string user, string msg[, scope])
 
 	Fetch a reply for the user. This returns a Promise that may be awaited on.
 	*/
@@ -86,7 +86,7 @@ class Brain {
 	}
 
 	/**
-	Promise _getReply (string user, string msg, string context, int step, scope)
+	async _getReply (string user, string msg, string context, int step, scope)
 
 	The internal reply method. DO NOT CALL THIS DIRECTLY.
 
@@ -197,7 +197,7 @@ class Brain {
 							// Huzzah! See if OUR message is right too.
 							self.say("Bot side matched!");
 
-							let thatstars = match; // Collect the bot stars in case we need them
+							thatstars = match; // Collect the bot stars in case we need them
 							thatstars.shift();
 
 							// Compare the triggers to the user's message.
@@ -721,7 +721,7 @@ class Brain {
 		for (let i = 1, len = stars.length; i <= len; i++) {
 			reply = reply.replace(new RegExp(`<star${i}>`, "ig"), stars[i]);
 		}
-		for (let i = 1, len = stars.length; i <= len; i++) {
+		for (let i = 1, len = botstars.length; i <= len; i++) {
 			reply = reply.replace(new RegExp(`<botstar${i}>`, "ig"), botstars[i]);
 		}
 

--- a/src/lang/coffee.js
+++ b/src/lang/coffee.js
@@ -10,68 +10,68 @@ var CoffeeObjectHandler, coffee;
 
 coffee = require("coffeescript");
 
-//#
-// CoffeeObjectHandler (RiveScript master)
+/**
+CoffeeObjectHandler (RiveScript master)
 
-// CoffeeScript Language Support for RiveScript Macros. This language is not
-// enabled by default; to enable CoffeeScript object macros:
+CoffeeScript Language Support for RiveScript Macros. This language is not
+enabled by default; to enable CoffeeScript object macros:
 
-// ```coffeescript
-//    CoffeeObjectHandler = require "rivescript/lang/coffee"
-//    bot.setHandler "coffee", new CoffeeObjectHandler
-// ```
-//#
+```coffeescript
+CoffeeObjectHandler = require "rivescript/lang/coffee"
+bot.setHandler "coffee", new CoffeeObjectHandler
+```
+*/
 CoffeeObjectHandler = class CoffeeObjectHandler {
-  constructor(master) {
-    this._master = master;
-    this._objects = {};
-  }
+	constructor(master) {
+		this._master = master;
+		this._objects = {};
+	}
 
-  //#
-  // void load (string name, string[] code)
+	/**
+	void load (string name, string[] code)
 
-  // Called by the RiveScript object to load CoffeeScript code.
-  //#
-  load(name, code) {
-    var e, source;
-    // We need to make a dynamic CoffeeScript function.
-    source = "this._objects[\"" + name + "\"] = function(rs, args) {\n" + coffee.compile(code.join("\n"), {
-      bare: true
-    }) + "}\n";
-    try {
-      return eval(source);
-    } catch (error) {
-      e = error;
-      return this._master.warn("Error evaluating CoffeeScript object: " + e.message);
-    }
-  }
+	Called by the RiveScript object to load CoffeeScript code.
+	*/
+	load(name, code) {
+		var e, source;
+		// We need to make a dynamic CoffeeScript function.
+		source = "this._objects[\"" + name + "\"] = function(rs, args) {\n" + coffee.compile(code.join("\n"), {
+			bare: true
+		}) + "}\n";
+		try {
+			return eval(source);
+		} catch (error) {
+			e = error;
+			return this._master.warn("Error evaluating CoffeeScript object: " + e.message);
+		}
+	}
 
-  //#
-  // string call (RiveScript rs, string name, string[] fields)
+	/**
+	string call (RiveScript rs, string name, string[] fields)
 
-  // Called by the RiveScript object to execute CoffeeScript code.
-  //#
-  call(rs, name, fields, scope) {
-    var e, func, reply;
-    // We have it?
-    if (!this._objects[name]) {
-      return this._master.errors.objectNotFound;
-    }
-    // Call the dynamic method.
-    func = this._objects[name];
-    reply = "";
-    try {
-      reply = func.call(scope, rs, fields);
-    } catch (error) {
-      e = error;
-      reply = `[ERR: Error when executing CoffeeScript object: ${e.message}]`;
-    }
-    // Allow undefined responses.
-    if (reply === void 0) {
-      reply = "";
-    }
-    return reply;
-  }
+	Called by the RiveScript object to execute CoffeeScript code.
+	*/
+	call(rs, name, fields, scope) {
+		var e, func, reply;
+		// We have it?
+		if (!this._objects[name]) {
+			return this._master.errors.objectNotFound;
+		}
+		// Call the dynamic method.
+		func = this._objects[name];
+		reply = "";
+		try {
+			reply = func.call(scope, rs, fields);
+		} catch (error) {
+			e = error;
+			reply = `[ERR: Error when executing CoffeeScript object: ${e.message}]`;
+		}
+		// Allow undefined responses.
+		if (reply === void 0) {
+			reply = "";
+		}
+		return reply;
+	}
 
 };
 

--- a/src/lang/javascript.js
+++ b/src/lang/javascript.js
@@ -8,71 +8,71 @@
 "use strict";
 var JSObjectHandler;
 
-//#
-// JSObjectHandler (RiveScript master)
+/**
+JSObjectHandler (RiveScript master)
 
-// JavaScript Language Support for RiveScript Macros. This support is enabled by
-// default in RiveScript.js; if you don't want it, override the `javascript`
-// language handler to null, like so:
+JavaScript Language Support for RiveScript Macros. This support is enabled by
+default in RiveScript.js; if you don't want it, override the `javascript`
+language handler to null, like so:
 
-// ```javascript
-//    bot.setHandler("javascript", null);
-// ```
-//#
+```javascript
+bot.setHandler("javascript", null);
+```
+*/
 JSObjectHandler = class JSObjectHandler {
-  constructor(master) {
-    this._master = master;
-    this._objects = {};
-  }
+	constructor(master) {
+		this._master = master;
+		this._objects = {};
+	}
 
-  //#
-  // void load (string name, string[]|function code)
+	/**
+	void load (string name, string[]|function code)
 
-  // Called by the RiveScript object to load JavaScript code.
-  //#
-  load(name, code) {
-    var e, source;
-    if (typeof code === "function") {
-      // If code is just a js function, store the reference as is
-      return this._objects[name] = code;
-    } else {
-      // We need to make a dynamic JavaScript function.
-      source = "this._objects[\"" + name + "\"] = function(rs, args) {\n" + code.join("\n") + "}\n";
-      try {
-        return eval(source);
-      } catch (error) {
-        e = error;
-        return this._master.warn("Error evaluating JavaScript object: " + e.message);
-      }
-    }
-  }
+	Called by the RiveScript object to load JavaScript code.
+	*/
+	load(name, code) {
+		var e, source;
+		if (typeof code === "function") {
+			// If code is just a js function, store the reference as is
+			return this._objects[name] = code;
+		} else {
+			// We need to make a dynamic JavaScript function.
+			source = "this._objects[\"" + name + "\"] = function(rs, args) {\n" + code.join("\n") + "}\n";
+			try {
+				return eval(source);
+			} catch (error) {
+				e = error;
+				return this._master.warn("Error evaluating JavaScript object: " + e.message);
+			}
+		}
+	}
 
-  //#
-  // string call (RiveScript rs, string name, string[] fields)
+	/**
+	string call (RiveScript rs, string name, string[] fields)
 
-  // Called by the RiveScript object to execute JavaScript code.
-  //#
-  call(rs, name, fields, scope) {
-    var e, func, reply;
-    // We have it?
-    if (!this._objects[name]) {
-      return this._master.errors.objectNotFound;
-    }
-    // Call the dynamic method.
-    func = this._objects[name];
-    reply = "";
-    try {
-      reply = func.call(scope, rs, fields);
-    } catch (error) {
-      e = error;
-      reply = `[ERR: Error when executing JavaScript object: ${e.message}]`;
-    }
-    // Allow undefined responses.
-    if (reply === void 0) {
-      reply = "";
-    }
-    return reply;
-  }
+	Called by the RiveScript object to execute JavaScript code.
+	*/
+	call(rs, name, fields, scope) {
+		var e, func, reply;
+		// We have it?
+		if (!this._objects[name]) {
+			return this._master.errors.objectNotFound;
+		}
+		// Call the dynamic method.
+		func = this._objects[name];
+		reply = "";
+		try {
+			reply = func.call(scope, rs, fields);
+		} catch (error) {
+			e = error;
+			reply = `[ERR: Error when executing JavaScript object: ${e.message}]`;
+		}
+		// Allow undefined responses.
+		if (reply === void 0) {
+			reply = "";
+		}
+		return reply;
+	}
 
 };
 

--- a/src/rivescript.js
+++ b/src/rivescript.js
@@ -383,7 +383,9 @@ const RiveScript = (function() {
 				}(file));
 			}
 
-			return Promise.all(promises);
+			return new Promise((resolve, reject) => {
+				Promise.all(promises).then(resolve).catch(reject);
+			})
 		}
 
 		// Load a file using ajax. DO NOT CALL THIS DIRECTLY.
@@ -397,7 +399,7 @@ const RiveScript = (function() {
 					var ref;
 					if (xhr.readyState === 4) {
 						let ref = xhr.status;
-						if (ref === 0 || ref === 200) {
+						if (ref === 200) {
 							self.say(`Loading file ${file} complete.`);
 
 							// Parse it!
@@ -410,8 +412,8 @@ const RiveScript = (function() {
 								reject("parser error");
 							}
 						} else {
-							self.say(`Ajax error! ${xhr.statusText}; ${xhr.status}`);
-							reject(`Ajax error: ${xhr.statusText}; ${xhr.status}`)
+							self.warn(`Network error in XMLHttpRequest for file ${file}`);
+							reject(`Failed to load file ${file}: network error`);
 						}
 					}
 				};

--- a/src/sorting.js
+++ b/src/sorting.js
@@ -22,7 +22,7 @@ debug logging from within this function.
 This function has two use cases:
 
 1. create a sort buffer for "normal" (matchable) triggers, which are triggers
-which are NOT accompanied by a %Previous tag.
+   which are NOT accompanied by a %Previous tag.
 2. create a sort buffer for triggers that had %Previous tags.
 
 Use the `exclude_previous` parameter to control which one is being done.

--- a/test/test-replies.js
+++ b/test/test-replies.js
@@ -12,6 +12,7 @@ exports.test_previous = async function(test) {
 		! sub who's  = who is
 		! sub it's   = it is
 		! sub didn't = did not
+		! array colors = red blue green black white
 
 		+ knock knock
 		- Who's there?
@@ -36,6 +37,13 @@ exports.test_previous = async function(test) {
 		% how many arms do i have
 		- That isn't a number.
 
+		+ i bought a new *
+		- What color is your new <star>?
+
+		+ (@colors)
+		% what color is your new *
+		- <sentence> is a pretty color for a <botstar1>.
+
 		+ *
 		- I don't know.
 	`);
@@ -49,6 +57,8 @@ exports.test_previous = async function(test) {
 	await bot.reply("2", "Yes!");
 	await bot.reply("Ask me a question", "How many arms do I have?");
 	await bot.reply("lol", "That isn't a number.");
+	await bot.reply("I bought a new car", "What color is your new car?");
+	await bot.reply("red", "Red is a pretty color for a car.");
 	return test.done();
 };
 

--- a/test/test-rivescript.js
+++ b/test/test-rivescript.js
@@ -12,12 +12,12 @@ exports.test_load_directory_recursively = function(test) {
         + *
         - No, this failed.
 	`);
-    return bot.rs.loadDirectory('./test/fixtures', async function() {
+    return bot.rs.loadDirectory('./test/fixtures').then(async function() {
         bot.rs.sortReplies();
         await bot.reply("Did the root directory rivescript load?", "Yes, the root directory rivescript loaded.");
         await bot.reply("Did the recursive directory rivescript load?", "Yes, the recursive directory rivescript loaded.");
         return test.done();
-    }, function() {
+    }, () => {
         return test.equal(true, false); // Throw error
     });
 };

--- a/test/test-triggers.js
+++ b/test/test-triggers.js
@@ -164,17 +164,15 @@ exports.test_weighted_triggers = async function(test) {
 };
 
 exports.test_empty_piped_arrays = async function(test) {
-	var bot, errors, expected_errors;
-	errors = [];
-	expected_errors = [
-		'Syntax error: Piped arrays can\'t begin or end with a | at stream() line 2 near ! array hello = hi|hey|sup|yo| (in topic random)',
-		'Syntax error: Piped arrays can\'t begin or end with a | at stream() line 3 near ! array something = |something|some thing (in topic random)',
-		'Syntax error: Piped arrays can\'t include blank entries at stream() line 4 near ! array nothing = nothing||not a thing (in topic random)'
+	let bot = new TestCase(test, ``);
+
+	let errors = [];
+	let expected_errors = [
+		'Syntax error: Piped arrays can\'t begin or end with a | at stream() line 2 near ! array hello = hi|hey|sup|yo|',
+		'Syntax error: Piped arrays can\'t begin or end with a | at stream() line 3 near ! array something = |something|some thing',
+		'Syntax error: Piped arrays can\'t include blank entries at stream() line 4 near ! array nothing = nothing||not a thing'
 	];
-	console.error = function(text) {
-		return errors.push(text);
-	};
-	bot = new TestCase(test, `
+	bot.rs.stream(`
 		! array hello = hi|hey|sup|yo|
 		! array something = |something|some thing
 		! array nothing = nothing||not a thing
@@ -184,7 +182,11 @@ exports.test_empty_piped_arrays = async function(test) {
 
 		+ *
 		- Anything else?
-	`);
+	`, function(err, filename, lineno) {
+		errors.push(err);
+	});
+	bot.rs.sortReplies();
+
 	// Check that errors were thrown
 	test.deepEqual(errors, expected_errors);
 	// We also fix these, so these should also work
@@ -196,17 +198,15 @@ exports.test_empty_piped_arrays = async function(test) {
 };
 
 exports.test_empty_piped_alternations = async function(test) {
-	var bot, errors, expected_errors;
-	errors = [];
-	expected_errors = [
-		'Syntax error: Piped alternations can\'t begin or end with a | at stream() line 2 near + [*] (hi|hey|sup|yo|) [*] (in topic random)',
-		'Syntax error: Piped alternations can\'t begin or end with a | at stream() line 5 near + [*] (|good|great|nice) [*] (in topic random)',
-		'Syntax error: Piped alternations can\'t include blank entries at stream() line 8 near + [*] (mild|warm||hot) [*] (in topic random)'
+	let bot = new TestCase(test, ``);
+
+	let errors = [];
+	let expected_errors = [
+		'Syntax error: Piped alternations can\'t begin or end with a | at stream() line 2 near + [*] (hi|hey|sup|yo|) [*]',
+		'Syntax error: Piped alternations can\'t begin or end with a | at stream() line 5 near + [*] (|good|great|nice) [*]',
+		'Syntax error: Piped alternations can\'t include blank entries at stream() line 8 near + [*] (mild|warm||hot) [*]'
 	];
-	console.error = function(text) {
-		return errors.push(text);
-	};
-	bot = new TestCase(test, `
+	bot.rs.stream(`
 		+ [*] (hi|hey|sup|yo|) [*]
 		- Oh hello there.
 
@@ -218,7 +218,11 @@ exports.test_empty_piped_alternations = async function(test) {
 
 		+ *
 		- Anything else?
-	`);
+	`, (err, filename, lineno) => {
+		errors.push(err);
+	});
+	bot.rs.sortReplies();
+
 	// Check that errors were thrown
 	test.deepEqual(errors, expected_errors);
 	// We also fix these, so these should also work
@@ -233,17 +237,15 @@ exports.test_empty_piped_alternations = async function(test) {
 };
 
 exports.test_empty_piped_optionals = async function(test) {
-	var bot, errors, expected_errors;
-	errors = [];
-	expected_errors = [
-		'Syntax error: Piped optionals can\'t begin or end with a | at stream() line 2 near + bot [*] [hi|hey|sup|yo|] [*] to me (in topic random)',
-		'Syntax error: Piped optionals can\'t begin or end with a | at stream() line 5 near + dog [*] [|good|great|nice] [*] to me (in topic random)',
-		'Syntax error: Piped optionals can\'t include blank entries at stream() line 8 near + cat [*] [mild|warm||hot] [*] to me (in topic random)'
+	let bot = new TestCase(test, ``);
+
+	let errors = [];
+	let expected_errors = [
+		'Syntax error: Piped optionals can\'t begin or end with a | at stream() line 2 near + bot [*] [hi|hey|sup|yo|] [*] to me',
+		'Syntax error: Piped optionals can\'t begin or end with a | at stream() line 5 near + dog [*] [|good|great|nice] [*] to me',
+		'Syntax error: Piped optionals can\'t include blank entries at stream() line 8 near + cat [*] [mild|warm||hot] [*] to me'
 	];
-	console.error = function(text) {
-		return errors.push(text);
-	};
-	bot = new TestCase(test, `
+	bot.rs.stream(`
 		+ bot [*] [hi|hey|sup|yo|] [*] to me
 		- Oh hello there.
 
@@ -255,7 +257,11 @@ exports.test_empty_piped_optionals = async function(test) {
 
 		+ *
 		- Anything else?
-	`);
+	`, (err, filename, lineno) => {
+		errors.push(err);
+	});
+	bot.rs.sortReplies();
+
 	// Check that errors were thrown
 	test.deepEqual(errors, expected_errors);
 	// We also fix these, so these should also work


### PR DESCRIPTION
# Changes

* `loadFile()` and `loadDirectory()` now return a Promise and do not handle the old callback-based system anymore.
* Update all examples in the `eg/` folder to use the new APIs (#269).
* Improves the web-client demo to be more user friendly by reporting better error messages.

## loadFile and loadDirectory

This breaks backwards compatibility for v2.0.0 by making the `loadFile()` and `loadDirectory()` methods Promise-based instead of callback-based. See #269 for the rationale.

To update your code:

```diff
- bot.loadDirectory("./brain", onSuccess, onError);
+ bot.loadDirectory("./brain").then(onSuccess).catch(onError);

- bot.loadFile("./brain/admin.rive", onSuccess, onError);
+ bot.loadFile("./brain/admin.rive").then(onSuccess).catch(onError);
```

`stream()` was left synchronous. I wanted to make it Promise-based too, just for consistency, but it was wreaking havoc on unit tests and I decided it didn't really _need_ to be Promise-based, since everything that happens inside `stream()` runs synchronously in the same thread anyway.

For lots of examples, see [the commit where I update all the examples to the new API](https://github.com/aichaos/rivescript-js/commit/2e6aae30bbecd4cba946ef95b085f023954dcb97?w=1).

## Improvements to web-client demo

I've made some nice quality-of-life improvements to the web client in the form of helpful error messages:

* If you open the chat.html locally (by double-clicking it in your file browser), it will display a warning on the page that the ajax requests to load the bot's brain will probably fail. This is a very common user error so now the page will tell you about it instead of just being broken.
* If the files do fail to load, it will log the network error in the chat dialogue window.
* If the page failed to load `rivescript.js` it will show a nice error message as well. This is usually because the user forgot to run `npm run dist` to create `dist/rivescript.js`, or they messed up the paths when uploading it to a server. The page now clearly spells out that rivescript.js itself did not load.

Altogether it should result in less tech support questions about the web-client demo. :smile: 

* Fixes #267 