### PR TITLE
Update TypeScript type definition file for v2.0.0 changes

### DIFF
--- a/rivescript.d.ts
+++ b/rivescript.d.ts
@@ -29,17 +29,17 @@ declare module "rivescript" {
 
 		Promise(callback: (resolve: (any) => void, reject: (any) => void) => void): void;
 
-		loadDirectory(brain: string, loadingDone: (batchNumber: number) => void, loadingError: (error: Error, batchNumber: number) => void);
+		loadDirectory(brain: string, loadingDone?: (batchNumber: number) => void, loadingError?: (error: Error, batchNumber: number) => void): Promise<any>;
 
-		loadFile(path: string, loadingDone: (batchNumber: number) => void, loadingError: (error: Error, batchNumber: number) => void);
+		loadFile(path: string, loadingDone?: (batchNumber: number) => void, loadingError?: (error: Error, batchNumber: number) => void): Promise<any>;
 
-		loadFile(paths: string[], loadingDone: (batchNumber: number) => void, loadingError: (error: Error, batchNumber: number) => void);
+		loadFile(paths: string[], loadingDone?: (batchNumber: number) => void, loadingError?: (error: Error, batchNumber: number) => void): Promise<any>;
 
 		stream(code: string, onError: (error: string) => void): boolean;
 
 		sortReplies();
 
-		reply(user: string, message: string): string;
+		reply(user: string, message: string, scope?: any): Promise<string>;
 
 		replyAsync(user: string, message: string, scope?: any): Promise<string>;
 


### PR DESCRIPTION
Fixes https://github.com/aichaos/rivescript-js/issues/276

- makes callback parameters optional for `loadDirectory()` and `loadFile()`, and adds `Promise<any>` return types for the same
- adds optional `scope` parameter and a `Promise<string>` return type for `reply()`