### PR TITLE
Update utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -213,7 +213,7 @@ exports.clone = function(obj) {
 	if (obj === null || typeof obj !== "object") {
 		return obj;
 	}
-	copy = obj.constructor();
+	copy = obj;
 	for (key in obj) {
 		if (!obj.hasOwnProperty(key)) {
 			continue;


### PR DESCRIPTION
the clone function is modified since it has problems when cloning objects whose constructor is not defined in the code, it is replaced by the real object