### PR TITLE
TypeScript declaration file: Fix return types and export assignment

### DIFF
--- a/rivescript.d.ts
+++ b/rivescript.d.ts
@@ -1,4 +1,3 @@
-
 declare module "rivescript" {
 
 	interface RivescriptOptions {
@@ -15,11 +14,11 @@ declare module "rivescript" {
 	}
 
 	interface Trigger {
-		trigger:    string,
-		reply:      string[],
-		condition:  string[],
-		redirect:   string,
-		previous:   string
+		trigger:    string;
+		reply:      string[];
+		condition:  string[];
+		redirect:   string;
+		previous:   string;
 	}
 
 	class RiveScript {
@@ -37,15 +36,13 @@ declare module "rivescript" {
 
 		stream(code: string, onError: (error: string) => void): boolean;
 
-		sortReplies();
+		sortReplies(): void;
 
 		reply(user: string, message: string, scope?: any): Promise<string>;
 
 		replyAsync(user: string, message: string, scope?: any): Promise<string>;
 
-		replyAsync(user: string, message: string, scope: any, callback: (error: Error, reply: string) => void);
-
-
+		replyAsync(user: string, message: string, scope: any, callback: (error: Error, reply: string) => void): Promise<string>;
 
 		setHandler(lang: string, handler: MacroObjectHandler): void;
 
@@ -59,26 +56,26 @@ declare module "rivescript" {
 
 		setPerson(name: string, value: string): void;
 
-		setUservar(user: string, name: string, value: any): void;
+		setUservar(user: string, name: string, value: any): Promise<void>;
 
-		setUservars(user: string, data: Object): void;
+		setUservars(user: string, data: { [index: string]: any }): Promise<void>;
 
 		getVariable(user: string, name: string): string;
 
-		getUservar(user: string, name: string): string;
+		getUservar(user: string, name: string): Promise<string>;
 
-		getUservars(user: string): Object;
+		getUservars(user: string): Promise<{ [index: string]: any }>;
 
-		clearUservars(user: string): void;
+		clearUservars(user: string): Promise<void>;
 
-		lastMatch(user: string): string;
+		lastMatch(user: string): Promise<string>;
 
-		initialMatch(user: string): string;
+		initialMatch(user: string): Promise<string>;
 
-		lastTriggers(user: string): Trigger[];
+		lastTriggers(user: string): Promise<Trigger[]>;
 
 		currentUser(): string;
 	}
 
-	export = RiveScript;
+	export default RiveScript;
 }


### PR DESCRIPTION
This change updates the return types of certain functions to their current (v2.x) `Promise`-based implementation, and fills in some holes where there were no annotations previously. It also fixes the following TypeScript error:

```
ERROR in /Users/Foo/bar-app/node_modules/rivescript/rivescript.d.ts
83:2 An export assignment cannot be used in a module with other exported elements.
    81 | 	}
    82 |
  > 83 | 	export = RiveScript;
       | 	^
    84 | }
    85 |
```