### PR TITLE
Proper types on Promise resolve/reject params

### DIFF
--- a/rivescript.d.ts
+++ b/rivescript.d.ts
@@ -26,7 +26,7 @@ declare module "rivescript" {
 
 		version(): string;
 
-		Promise(callback: (resolve: (any) => void, reject: (any) => void) => void): void;
+		Promise(callback: (resolve: (...args: any[]) => void, reject: (reason?: any) => void) => void): void;
 
 		loadDirectory(brain: string, loadingDone?: (batchNumber: number) => void, loadingError?: (error: Error, batchNumber: number) => void): Promise<any>;
 


### PR DESCRIPTION
This one only shows up once you set the compiler to `"strict": true`! Missed it until now.