### PR TITLE
Flesh out TS declarations to properly reflect public interface

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -2,11 +2,11 @@
 
 Create a Brain object which handles the actual process of fetching a reply.
 
-## async reply (string user, string msg[, scope])
+## async reply (string user, string msg[, scope]) -> string
 
 Fetch a reply for the user. This returns a Promise that may be awaited on.
 
-## async _getReply (string user, string msg, string context, int step, scope)
+## private async _getReply (string user, string msg, string context, int step, scope) -> string
 
 The internal reply method. DO NOT CALL THIS DIRECTLY.
 
@@ -15,15 +15,15 @@ The internal reply method. DO NOT CALL THIS DIRECTLY.
 * step = the recursion depth
 * scope = the call scope for object macros
 
-## string formatMessage (string msg)
+## async formatMessage (string msg) -> string
 
 Format a user's message for safe processing.
 
-## async triggerRegexp (string user, string trigger)
+## async triggerRegexp (string user, string trigger) -> string
 
 Prepares a trigger for the regular expression engine.
 
-## string processTags (string user, string msg, string reply, string[] stars, string[] botstars, int step, scope)
+## async processTags (string user, string msg, string reply, string[] stars, string[] botstars, int step, scope) -> string
 
 Process tags in a reply element.
 

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -15,7 +15,7 @@ The internal reply method. DO NOT CALL THIS DIRECTLY.
 * step = the recursion depth
 * scope = the call scope for object macros
 
-## async formatMessage (string msg) -> string
+## string formatMessage (string msg)
 
 Format a user's message for safe processing.
 

--- a/docs/rivescript.md
+++ b/docs/rivescript.md
@@ -309,11 +309,11 @@ Set the value to `undefined` to delete a substitution.
 Set a person substitution. This is equivalent to `! person` in RiveScript.
 Set the value to `undefined` to delete a person substitution.
 
-## async setUservar (string user, string name, string value)
+## async setUservar (string user, string name, string value) -> void
 
 Set a user variable for a user.
 
-## async setUservars (string user, object data)
+## async setUservars (string user, object data) -> void
 
 Set multiple user variables by providing an object of key/value pairs.
 Equivalent to calling `setUservar()` for each pair in the object.
@@ -332,18 +332,18 @@ defined.
 Get all variables about a user. If no user is provided, returns all data
 about all users.
 
-## async clearUservars ([string user])
+## async clearUservars ([string user]) -> void
 
 Clear all a user's variables. If no user is provided, clears all variables
 for all users.
 
-## async freezeUservars (string user)
+## async freezeUservars (string user) -> void
 
 Freeze the variable state of a user. This will clone and preserve the user's
 entire variable state, so that it can be restored later with
 `thawUservars()`
 
-## async thawUservars (string user[, string action])
+## async thawUservars (string user[, string action]) -> void
 
 Thaw a user's frozen variables. The action can be one of the following:
 * discard: Don't restore the variables, just delete the frozen copy.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -30,7 +30,7 @@ var bot = new RiveScript({
 To implement your own session manager, you should extend the
 `SessionManager` class and implement a compatible object.
 
-## void set(string username, object data)
+## async set(string username, object data) -> void
 
 Set user variables for the user `username`. The `args` should be an object
 of key/value pairs. The values are usually strings, but they can be other
@@ -74,21 +74,21 @@ variables. For example:
 }
 ```
 
-## async reset(string username)
+## async reset(string username) -> void
 
 Reset all variables stored about a particular user.
 
-## async resetAll()
+## async resetAll() -> void
 
 Reset all data about all users.
 
-## async freeze(string username)
+## async freeze(string username) -> void
 
 Make a snapshot of the user's variables so that they can be restored
 later via `thaw()`. This is the implementation for
 `RiveScript.freezeUservars()`
 
-## async thaw(string username, string action)
+## async thaw(string username, string action) -> void
 
 Restore the frozen snapshot of variables for a user.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rivescript",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2904,8 +2904,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2926,14 +2925,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2948,20 +2945,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3078,8 +3072,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3091,7 +3084,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3106,7 +3098,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3114,14 +3105,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3140,7 +3129,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3221,8 +3209,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3234,7 +3221,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3320,8 +3306,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3357,7 +3342,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3377,7 +3361,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3421,14 +3404,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7388,9 +7369,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
-      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel-preset-env": "^1.7.0",
     "commander": "^2.19.0",
     "nodeunit": "^0.11.3",
+    "typescript": "^3.3.4000",
     "uglify-js": "^3.4.9",
     "webpack": "^4.29.5",
     "webpack-cli": "^3.2.3"

--- a/rivescript.d.ts
+++ b/rivescript.d.ts
@@ -99,7 +99,7 @@ declare module "rivescript" {
 		public unicodePunctuation: RegExp;
 		public errors: RiveScriptErrors;
 		public parser: Parser;
-		public Brain: Brain;
+		public brain: Brain;
 
 		constructor(options?: RiveScriptOptions);
 

--- a/rivescript.d.ts
+++ b/rivescript.d.ts
@@ -54,7 +54,7 @@ declare module "rivescript" {
 
 		reply(user: string, msg: string, scope?: any): Promise<string>;
 
-		formatMessage(msg: string, botreply?: null): Promise<string>;
+		formatMessage(msg: string, botreply?: null): string;
 
 		triggerRegexp(msg: string, botreply: string): Promise<string>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,90 @@
+// This file is mainly here to have intellisense in the rivescript.d.ts file.
+// Since there aren't [yet] any TypeScript files to compile, it doesn't matter
+// too much. But these are some good configuration choices if kirsle or other
+// contributors decide to use TypeScript in the project.
+
+{
+  "compilerOptions": {
+    // Allow default imports where no default export is actually specified. See
+    // the comment above "esModuleInterop" for more details
+    "allowSyntheticDefaultImports": true,
+
+    // Base directory to check when resolving module names in import statements
+    // which are not relative paths
+    "baseUrl": ".",
+
+    // Allows default imports where no default export is specified, and a little
+    // more. See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html
+    "esModuleInterop": true,
+
+    // Windows and MacOS filesystems are not case-sensitive, so a capitalization
+    // mistake in an import/require statement while developing won't do much
+    // harm. But filesystems for Linux commonly *are* case-sensitive, so it can
+    // lead to some issues if development switches over to one that is. This
+    // option won't fully protect you from a capitalization typo in an import
+    // statement, but it will at least warn you if you have referred to the same
+    // file with different casing somewhere else in the project.
+    "forceConsistentCasingInFileNames": true,
+
+    // Recognize ESNext and DOM vocabulary
+    "lib": ["esnext", "dom"],
+
+    // What module strategy to output (UMD allows the consumer of the resulting
+    // code to use any of the common module strategies; AMD, CommonJS, etc.)
+    "module": "umd",
+
+    // How to look up module imports within your TS files
+    "moduleResolution": "node",
+
+    // Generates a map from your source code to your compiled code for debugging
+    // purposes
+    "sourceMap": true,
+
+    // This option is a roll-up of a few good-practice compiler options; you can
+    // see https://www.typescriptlang.org/docs/handbook/compiler-options.html
+    // for more information. It is equivalent to setting the following options
+    // to true.
+    //
+    //   noImplicitAny:
+    //     Scold you if you write a declaration or expression which you have not
+    //     annotated (and is therefore implied to be `any`)
+    //
+    //   noImplicitThis:
+    //     If you write a function which is intended to be run in some context
+    //     where you can access `this`, and it's not obvious what `this` is,
+    //     force you to annotate the type of `this`
+    //
+    //   alwaysStrict:
+    //     Parse in strict mode and emit "use strict" for each source file
+    //
+    //   strictBindCallApply:
+    //     Properly type-check uses of `.bind()`, `.call()`, and `.apply()` on
+    //     functions
+    //
+    //   strictNullChecks:
+    //     Yell if the type might be null or undefined when you're assuming it's
+    //     there, and force you to explicitly tell the compiler otherwise if you
+    //     know better
+    //
+    //   strictFunctionTypes:
+    //     This has to do with contravariance vs. bivariance in function types
+    //     (read: magic). For more info, see the following from the TS handbook:
+    //     https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html
+    //
+    //   strictPropertyInitialization:
+    //     Makes sure you initialize properties of classes at some point in the
+    //     constructor, or forces you to explicitly tell the compiler to trust
+    //     that it's going to be initialized later
+    //
+    "strict": true,
+
+    // If we *were* to be authoring TypeScript in this project, TS would compile
+    // plainly to the equivalent JavaScript (as opposed to targeting an older
+    // standard), and then Babel would take it from there (targeting, e.g., ES5
+    // or whatever is specified in .babelrc).
+    "target": "esnext"
+  },
+  "exclude": [
+    "node_modules"
+  ],
+}


### PR DESCRIPTION
Hey! So, I found that a couple properties/methods I was trying to use in subroutines (public stuff) were not reflected in the type definition file. This PR adds a whole bunch of stuff to `rivescript.d.ts`, and fixes/adds to some method documentation (including explicitly mentioning when the resolved value of a promise is `void`—hope that's okay).

In the process, I added `typescript` to the `"devDependencies"` in `package.json`; I hope that's all right, too. I figured having it there for _development_ wouldn't be an issue, and it helps out with using the declaration file properly. I also added a basic `tsconfig.json` file (which I annotated so it would be more clear) in order to see error consistency in the `rivescript.d.ts` file when contributors are editing it. One of the nice side effects of this is that certain editors _(ahem, VSCode)_ can actually give you some really powerful intellisense/type inference even in plain JavaScript files due to the TypeScript language server being, uh, _ridiculously sweet._ So you might actually get some extra hover-info and code completion out of it... no promises, though 😉