### PR TITLE
Fix stringify: key is not defined when variables are present

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -618,7 +618,7 @@ const Parser = class Parser {
 		for (let j = 0, len = ref.length; j < len; j++) {
 			let begin = ref[j];
 			if ((deparsed.begin[begin] != null) && Object.keys(deparsed.begin[begin]).length) {
-				for (key in deparsed.begin[begin]) {
+				for (const key in deparsed.begin[begin]) {
 					let value = deparsed.begin[begin][key];
 					if (!deparsed.begin[begin].hasOwnProperty(key)) {
 						continue;


### PR DESCRIPTION
Define 'key' inside the stringify function due to receiving 'key is not defined' error when bot contains variables.