### PR TITLE
Include error message when error raised by object macro

### DIFF
--- a/src/brain.js
+++ b/src/brain.js
@@ -974,7 +974,7 @@ class Brain {
 						if (error != undefined) {
 							self.warn(error);
 						}
-						output = "[ERR: Error raised by object macro]";
+						output = `[ERR: Error raised by object macro: ${error.message}]`;
 					}
 				} else {
 					output = "[ERR: No Object Handler]";

--- a/test/test-objects.js
+++ b/test/test-objects.js
@@ -421,3 +421,28 @@ exports.test_await_macro = async function(test) {
 	await bot.reply("test async", "Ok: Alice, you have called this macro 3 times.");
 	test.done();
 };
+
+exports.test_error_in_await_macro = async function(test) {
+	// In RiveScript 2.0.0, macros parsed from RiveScript code are loaded as
+	// async functions, allowing them to use the await keyword.
+
+	// Test if we have async support in our local JS environment, or else skip
+	// this test.
+	try {
+		eval("(async function() {})");
+	} catch(e) {
+		console.log("skip test_error_in_await_macro: local JS environment doesn't support async/await");
+		return test.done();
+	}
+
+	var bot = new TestCase(test, `
+		> object awaitable javascript
+			throw new Error('TestError');
+		< object
+
+		+ test async
+		- Ok: <call>awaitable</call>
+	`);
+	await bot.reply("test async", "Ok: [ERR: Error raised by object macro: TestError]");
+	test.done();
+};

--- a/test/test-objects.js
+++ b/test/test-objects.js
@@ -389,7 +389,7 @@ exports.test_await_macro = async function(test) {
 	// Test if we have async support in our local JS environment, or else skip
 	// this test.
 	try {
-		eval("(asyc function() {})");
+		eval("(async function() {})");
 	} catch(e) {
 		console.log("skip test_await_macro: local JS environment doesn't support async/await");
 		return test.done();


### PR DESCRIPTION
This PR includes the error message in the response when error is raised within an object macro.

When an error is raised in an object, the error message is included along with the default error response, e.g. `[ERR: Error when executing JavaScript object: TypeError]`. Very useful for debugging & testing!

However, when an error is raised in an async object macro, instead of returning the above default error reply, it only returns `[ERR: Error raised by object macro]`. Adding error message to follow similar pattern above.

Test added to cover this.

👉  Take note of the misspelling in the tests of `asyc` that was preventing await tests from running.